### PR TITLE
support ltl temporal logic in circt-bmc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,41 @@
   "nodes": {
     "circt-nix": {
       "inputs": {
+        "circt-src": "circt-src",
         "flake-compat": "flake-compat",
+        "llvm-src": "llvm-src",
         "nixpkgs": "nixpkgs",
         "slang-src": "slang-src"
       },
       "locked": {
-        "lastModified": 1785378254,
-        "narHash": "sha256-++zRS2XFCGjQCwjTf7A4QUboXxIEEIruYTC+4D7ue/8=",
+        "lastModified": 1786424114,
+        "narHash": "sha256-XXURQeU/3g8+tGdjkVGtWU3D0+sp6bx+lX6g4G+czIc=",
         "owner": "xinpian-tech",
         "repo": "circt-nix",
-        "rev": "03880ddceed5eb4d88e3e89e50c398172d068615",
+        "rev": "af47017089200cf4c5ee8d11d89a76a26c1cc486",
         "type": "github"
       },
       "original": {
         "owner": "xinpian-tech",
         "ref": "xinpian-main",
         "repo": "circt-nix",
+        "type": "github"
+      }
+    },
+    "circt-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786387434,
+        "narHash": "sha256-1jBFiuhFcfz70d7Q8cThDYY31qbfSUFJGnpd29bDiYA=",
+        "owner": "xinpian-tech",
+        "repo": "circt",
+        "rev": "a2621cd17dc88a9864b8f8a35353e61fb2ba6753",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xinpian-tech",
+        "ref": "master",
+        "repo": "circt",
         "type": "github"
       }
     },
@@ -128,6 +147,23 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "llvm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783919289,
+        "narHash": "sha256-epMcDIyD3zwgH4r4DqvXW0pUHTanXhm+CPaGE53WD7s=",
+        "owner": "llvm",
+        "repo": "llvm-project",
+        "rev": "b1c56fb53a9c76d6b045ede49083b647ae049ffe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "llvm",
+        "repo": "llvm-project",
+        "rev": "b1c56fb53a9c76d6b045ede49083b647ae049ffe",
         "type": "github"
       }
     },

--- a/stdlib/lit/tests/TemporalLogic.scala
+++ b/stdlib/lit/tests/TemporalLogic.scala
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+
+// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.TemporalLogic" %s --
+// DEFINE: %{bmc} = circt-bmc %t.dir/w4.bmc.hw.mlir --module=TemporalLogic_width4_CheckContract_0 -b 4 --shared-libs=%Z3LIB --run
+
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %{test} config %t.dir/w4.json --width 4
+// RUN: FileCheck %s -check-prefix=CONFIG --input-file=%t.dir/w4.json
+// RUN: cd %t.dir && %{test} design %t.dir/w4.json
+// RUN: circt-opt %t.dir/TemporalLogic_width4.mlirbc | FileCheck %s -check-prefix=FIRRTL
+// RUN: firtool %t.dir/TemporalLogic_width4.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/w4.contract.hw.mlir --disable-output
+// RUN: circt-opt %t.dir/w4.contract.hw.mlir --strip-om --symbol-dce -o %t.dir/w4.clean.hw.mlir
+// RUN: FileCheck %s -check-prefix=LOWERED --input-file=%t.dir/w4.clean.hw.mlir
+// RUN: circt-opt %t.dir/w4.clean.hw.mlir --pass-pipeline='builtin.module(verif-lower-tests,hw.module(lower-ltl-to-core,lower-seq-shiftreg,lower-seq-compreg-ce,canonicalize))' -o %t.dir/w4.bmc.hw.mlir
+// RUN: FileCheck %s -check-prefix=CORE --input-file=%t.dir/w4.bmc.hw.mlir
+// RUN: %{bmc} | FileCheck %s -check-prefix=BMC
+// RUN: rm -rf %t.dir
+
+// CONFIG: {"width":4}
+
+// FIRRTL-LABEL: firrtl.circuit "TemporalLogic_width4"
+// FIRRTL: firrtl.contract
+// FIRRTL-COUNT-8: firrtl.int.ltl.clocked_delay
+// FIRRTL: firrtl.int.ltl.implication
+// FIRRTL: firrtl.int.ltl.and
+// FIRRTL: firrtl.int.verif.ensure
+// FIRRTL-SAME: one_cycle_delay_matches
+
+// LOWERED-LABEL: verif.formal @TemporalLogic_width4_CheckContract_0
+// LOWERED: ltl.clocked_delay
+// LOWERED: ltl.implication
+// LOWERED: verif.assert
+// LOWERED-SAME: one_cycle_delay_matches
+
+// CORE-LABEL: hw.module @TemporalLogic_width4_CheckContract_0
+// CORE-NOT: ltl.
+// CORE-NOT: seq.shiftreg
+// CORE: verif.assert
+
+// BMC: Bound reached with no violations!
+
+package me.jiuyang.stdlib
+
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.ltltpe.*
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+
+case class TemporalLogicParameter(width: Int) extends Parameter:
+  require(width > 0, s"width must be positive, got $width")
+
+given upickle.default.ReadWriter[TemporalLogicParameter] = upickle.default.macroRW
+
+class TemporalLogicLayers(parameter: TemporalLogicParameter) extends LayerInterface(parameter):
+  def layers = Seq.empty
+
+class TemporalLogicIO(parameter: TemporalLogicParameter) extends HWBundle(parameter):
+  val clock  = Flipped(Clock())
+  val input  = Flipped(Bits(parameter.width))
+  val output = Aligned(Bits(parameter.width))
+
+class TemporalLogicProbe(parameter: TemporalLogicParameter)
+    extends DVBundle[TemporalLogicParameter, TemporalLogicLayers](parameter)
+
+@generator
+object TemporalLogic
+    extends Generator[TemporalLogicParameter, TemporalLogicLayers, TemporalLogicIO, TemporalLogicProbe]:
+  override def moduleName(parameter: TemporalLogicParameter): String = s"TemporalLogic_width${parameter.width}"
+
+  def architecture(parameter: TemporalLogicParameter) =
+    val io           = summon[Interface[TemporalLogicIO]]
+    given ClockScope = ClockScope.posedge(io.clock)
+
+    val delayed = Reg(Bits(parameter.width))
+    delayed   := io.input
+    io.output := delayed
+
+    Contract {
+      given ClockEvent = posedge(io.clock)
+
+      val outputFollowsInput = (0 until parameter.width)
+        .map: bit =>
+          val inputBit  = io.input.bit(bit)
+          val outputBit = io.output.bit(bit)
+          (inputBit.S |=> outputBit.S) & ((!inputBit).S |=> (!outputBit).S)
+        .reduce(_ & _)
+
+      Ensure(outputFollowsInput, "one_cycle_delay_matches")
+    }

--- a/stdlib/src/AbsVal.scala
+++ b/stdlib/src/AbsVal.scala
@@ -41,7 +41,7 @@ object AbsVal extends Generator[AbsValParameter, AbsValLayers, AbsValIO, AbsValP
     val checkedAbsVal = Contract(absVal) { value =>
       val negExpected = (0.U(parameter.width) - io.A.asUInt).asBits.bits(parameter.width - 1, 0)
       val expected    = sign ? (negExpected, io.A)
-      Ensure((value === expected).I, Some("absval_matches_abs"))
+      Ensure((value === expected).I, "absval_matches_abs")
     }
 
     io.ABSVAL := checkedAbsVal

--- a/stdlib/src/BrentKungAdder.scala
+++ b/stdlib/src/BrentKungAdder.scala
@@ -111,7 +111,7 @@ object BrentKungAdder
     val (checkedCO, checkedSUM) = Contract((carryOut, sumWord)) { case (co, sum) =>
       val observed = (co.asBits ## sum).asUInt
       val expected = (io.A.asUInt + io.B.asUInt + io.CI.asBits.asUInt).asBits.bits(width, 0).asUInt
-      Ensure((observed === expected).I, Some("prefix_adder_matches_add"))
+      Ensure((observed === expected).I, "prefix_adder_matches_add")
     }
 
     io.SUM := checkedSUM

--- a/stdlib/src/Incrementer.scala
+++ b/stdlib/src/Incrementer.scala
@@ -58,7 +58,7 @@ object Incrementer
 
     val checkedSUM = Contract(sumWord) { sum =>
       val expected = (io.A.asUInt + 1.U(width)).asBits.bits(width - 1, 0)
-      Ensure((sum === expected).I, Some("incrementer_matches_add"))
+      Ensure((sum === expected).I, "incrementer_matches_add")
     }
 
     io.SUM := checkedSUM

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -1162,8 +1162,34 @@ trait ContractApi:
   ): ContractTuple[A]
 
   def Require(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit
+
+  def Ensure(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit
+
+  def Require(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,
@@ -1175,7 +1201,7 @@ trait ContractApi:
 
   def Ensure(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -1164,8 +1164,34 @@ trait ContractApi:
   ): ContractTuple[A]
 
   def Require(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit
+
+  def Ensure(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit
+
+  def Require(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,
@@ -1177,7 +1203,7 @@ trait ContractApi:
 
   def Ensure(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,

--- a/zaozi/src/default/ContractApi.scala
+++ b/zaozi/src/default/ContractApi.scala
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Jianhao Ye <clo91eaf@qq.com>
 package me.jiuyang.zaozi.default
 
-import me.jiuyang.zaozi.{ContractApi, ContractTuple, ContractTupleArgs, TypeImpl}
+import me.jiuyang.zaozi.{ContractApi, ContractTuple, ContractTupleArgs, InstanceContext, TypeImpl}
 import me.jiuyang.zaozi.ltltpe.{Immediate, Property, Sequence}
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
@@ -39,6 +39,7 @@ export given_ContractApi.{Contract, Ensure, Require}
 
 given ContractApi with
   private def operationIsNull(op: Operation): Boolean = MlirOperation.ptr(op.segment).address == 0
+
   // Lower all public Contract overloads through a flat Seq, while preserving the
   // user-facing body argument and result shapes through the mapping functions.
   private def mapped[R, O](
@@ -167,8 +168,48 @@ given ContractApi with
     )(body)
 
   def Require(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit =
+    val value = property match
+      case immediate: Immediate => immediate.refer
+      case sequence:  Sequence  => sequence.refer
+      case prop:      Property  => prop.refer
+    if contractScopes.nonEmpty then
+      contractScopes.last.append(ContractClause(ContractClauseKind.Require, value, Some(valName), locate))
+    else summon[VerifAssumeApi].op(value, Some(valName), locate).operation.appendToBlock()
+
+  def Ensure(
+    property: Immediate | Sequence | Property
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    TypeImpl
+  ): Unit =
+    val value = property match
+      case immediate: Immediate => immediate.refer
+      case sequence:  Sequence  => sequence.refer
+      case prop:      Property  => prop.refer
+    if contractScopes.nonEmpty then
+      contractScopes.last.append(ContractClause(ContractClauseKind.Ensure, value, Some(valName), locate))
+    else summon[VerifAssertApi].op(value, Some(valName), locate).operation.appendToBlock()
+
+  def Require(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,
@@ -182,12 +223,12 @@ given ContractApi with
       case sequence:  Sequence  => sequence.refer
       case prop:      Property  => prop.refer
     if contractScopes.nonEmpty then
-      contractScopes.last.append(ContractClause(ContractClauseKind.Require, value, label, locate))
-    else summon[VerifAssumeApi].op(value, label, locate).operation.appendToBlock()
+      contractScopes.last.append(ContractClause(ContractClauseKind.Require, value, Some(label), locate))
+    else summon[VerifAssumeApi].op(value, Some(label), locate).operation.appendToBlock()
 
   def Ensure(
     property: Immediate | Sequence | Property,
-    label:    Option[String] = None
+    label:    String
   )(
     using Arena,
     Context,
@@ -200,7 +241,6 @@ given ContractApi with
       case immediate: Immediate => immediate.refer
       case sequence:  Sequence  => sequence.refer
       case prop:      Property  => prop.refer
-
     if contractScopes.nonEmpty then
-      contractScopes.last.append(ContractClause(ContractClauseKind.Ensure, value, label, locate))
-    else summon[VerifAssertApi].op(value, label, locate).operation.appendToBlock()
+      contractScopes.last.append(ContractClause(ContractClauseKind.Ensure, value, Some(label), locate))
+    else summon[VerifAssertApi].op(value, Some(label), locate).operation.appendToBlock()

--- a/zaozi/tests/src/ContractSpec.scala
+++ b/zaozi/tests/src/ContractSpec.scala
@@ -37,8 +37,7 @@ object ContractSpec extends TestSuite:
             ContractSpecIO,
             ContractSpecProbe
           ]
-          with HasMlirTest
-          with HasVerilogTest:
+          with HasMlirTest:
         def architecture(parameter: ContractSpecParameter) =
           val io = summon[Interface[ContractSpecIO]]
           val p  = io.p
@@ -54,12 +53,12 @@ object ContractSpec extends TestSuite:
         "  %0 = firrtl.geq %p, %c1_ui1 : (!firrtl.uint<8>, !firrtl.uint<1>) -> !firrtl.uint<1>",
         "  %_GEN_0 = firrtl.node interesting_name %0 : !firrtl.uint<1>",
         "  %1 = firrtl.add %p, %p : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>",
-        "  %_GEN_1 = firrtl.node interesting_name %1 : !firrtl.uint<9>",
+        "  %_GEN_2 = firrtl.node interesting_name %1 : !firrtl.uint<9>",
         "  %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>",
-        "  %2 = firrtl.geq %_GEN_1, %c2_ui2 : (!firrtl.uint<9>, !firrtl.uint<2>) -> !firrtl.uint<1>",
-        "  %_GEN_2 = firrtl.node interesting_name %2 : !firrtl.uint<1>",
-        "  firrtl.int.verif.require %_GEN_0 : !firrtl.uint<1>",
-        "  firrtl.int.verif.ensure %_GEN_2 : !firrtl.uint<1>",
+        "  %2 = firrtl.geq %_GEN_2, %c2_ui2 : (!firrtl.uint<9>, !firrtl.uint<2>) -> !firrtl.uint<1>",
+        "  %_GEN_3 = firrtl.node interesting_name %2 : !firrtl.uint<1>",
+        "  firrtl.int.verif.require %_GEN_0 {label = \"_GEN_1\"} : !firrtl.uint<1>",
+        "  firrtl.int.verif.ensure %_GEN_3 {label = \"_GEN_4\"} : !firrtl.uint<1>",
         "}"
       )
 


### PR DESCRIPTION
Previous we add temporal logic in circt-bmc, in [our fork](https://github.com/xinpian-tech/circt/pull/15)
Now we can use LTL temporal logic in the verification flow, especially in the circt-bmc flow, there is a usage case in the second commit.
Btw, for the first commit is just a nit fix for require/ensure api, aligned with the Assert/Cover/Assume style. It can be split into different pr if needed.
