### PR TITLE
[stdlib] add signal bound MMIO register map API

### DIFF
--- a/mtf.lock.json
+++ b/mtf.lock.json
@@ -5647,14 +5647,14 @@
       }
     },
     "org/scala-lang/scala3-library_3": {
-      "narHash": "sha256-11PZpVx7Cm/kmYuYaVuVyngqRKwR5E6/6FpO8g2RXT0=",
+      "narHash": "sha256-zRqT4JIVEXr3E6iapJgxcrndiu9gOSBhsAbxIGMsaw4=",
       "runs": [
         "104bb53c6cb5",
         "7044fbf8e835"
       ],
       "files": {
-        "maven-metadata.xml": "sha256-XVuewNsuuJP6pIFFXuk+uJX5iTVB4pBlCRyNL9EXtAw=",
-        "maven-metadata.xml.sha1": "sha256-2VVjDSHV8k5x1lW2wPRaiarzIj0T+JXcUiC29zt89Y8="
+        "maven-metadata.xml": "sha256-l2lz+yiQT098R8fhhtbC+20m0tiae48Uz5gH2kLZCPA=",
+        "maven-metadata.xml.sha1": "sha256-SsIC1rrEnpYNmAR4ahMBAc9AqMvmW6GiCG+SgjLwwvY="
       }
     },
     "org/scala-lang/scala3-library_3/3.3.1": {

--- a/stdlib/lit/tests/RegMapSpec.scala
+++ b/stdlib/lit/tests/RegMapSpec.scala
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Huang Rui <vowstar@gmail.com>
+
+// DEFINE: %{read} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class RegMapRead %s --
+// DEFINE: %{write} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class RegMapWrite %s --
+
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %{read} config %t.dir/read.json
+// RUN: cd %t.dir && %{read} design %t.dir/read.json
+// RUN: firtool %t.dir/RegMapRead.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/read.hw.mlir --disable-output
+// RUN: sed -E -e '/hw.instance "verification"/d' -e '/sv.bind <@RegMapRead::@verification>/d' %t.dir/read.hw.mlir > %t.dir/read.nobind.hw.mlir
+// RUN: circt-opt %t.dir/read.nobind.hw.mlir --strip-emit --strip-om --symbol-dce -o %t.dir/read.nomacro.hw.mlir
+// RUN: sed -E -e '/sv.macro.decl/d' -e 's/ sym @[A-Za-z0-9_.$-]+//' %t.dir/read.nomacro.hw.mlir > %t.dir/read.noinner.hw.mlir
+// RUN: circt-opt %t.dir/read.noinner.hw.mlir --canonicalize --cse -o %t.dir/read.clean.hw.mlir
+// RUN: circt-bmc %t.dir/read.clean.hw.mlir --module=RegMapRead_CheckContract_0 -b 10 --ignore-asserts-until=2 --shared-libs=%Z3LIB --run | FileCheck %s --check-prefix=BMC
+// RUN: firtool %t.dir/RegMapRead.mlirbc | FileCheck %s --check-prefix=LAYERS
+// RUN: %{write} config %t.dir/write.json
+// RUN: cd %t.dir && %{write} design %t.dir/write.json
+// RUN: firtool %t.dir/RegMapWrite.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/write.hw.mlir --disable-output
+// RUN: sed -E -e '/hw.instance "verification"/d' -e '/sv.bind <@RegMapWrite::@verification>/d' %t.dir/write.hw.mlir > %t.dir/write.nobind.hw.mlir
+// RUN: circt-opt %t.dir/write.nobind.hw.mlir --strip-emit --strip-om --symbol-dce -o %t.dir/write.nomacro.hw.mlir
+// RUN: sed -E -e '/sv.macro.decl/d' -e 's/ sym @[A-Za-z0-9_.$-]+//' %t.dir/write.nomacro.hw.mlir > %t.dir/write.noinner.hw.mlir
+// RUN: circt-opt %t.dir/write.noinner.hw.mlir --canonicalize --cse -o %t.dir/write.clean.hw.mlir
+// RUN: circt-bmc %t.dir/write.clean.hw.mlir --module=RegMapWrite_CheckContract_0 -b 10 --ignore-asserts-until=2 --shared-libs=%Z3LIB --run | FileCheck %s --check-prefix=BMC
+// RUN: rm -rf %t.dir
+
+// LAYERS-LABEL: module RegMapRead_Verification(
+// LAYERS:         assert property
+// LAYERS:         cover property
+// LAYERS-LABEL: module RegMapRead(
+// LAYERS-NOT:     assert
+// LAYERS-NOT:     cover
+
+// BMC: Bound reached with no violations!
+
+import me.jiuyang.stdlib.*
+import me.jiuyang.stdlib.mmio.*
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.magic.macros.generator
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+
+// queueEntries = 1: the response lands the cycle after its request is accepted.
+// Properties relate this cycle to the previous one, so they hold from any initial state without a reset assumption.
+// The RegMap assertion layer is stripped: the contracts are an independent oracle.
+// Every property here fails on the RegMap as it stands before this series.
+// Clauses are contract operands because an operand-free `Contract:` crashes lower-contracts.
+
+case class RegMapReadParameter() extends Parameter:
+  val status     = RegField("status", 8).readValue
+  val sample     = RegField("sample", 8).readReadyValid
+  val verification = Layer("Verification")
+  val regMap     = RegMapDefinition(
+    indexWidth = 6,
+    dataWidth = 32,
+    queueEntries = 1,
+    reportError = true,
+    assertionLayer = verification
+  )(
+    0x00 -> Seq(status),
+    0x04 -> Seq(sample)
+  )
+
+given upickle.default.ReadWriter[RegMapReadParameter] = upickle.default.macroRW
+
+class RegMapReadLayers(parameter: RegMapReadParameter) extends LayerInterface(parameter):
+  def layers = Seq(parameter.verification)
+
+class RegMapReadIO(parameter: RegMapReadParameter) extends HWBundle(parameter):
+  val clock        = Flipped(Clock())
+  val reset        = Flipped(Reset())
+  val req          = Flipped(Decoupled(new RegMapRequest(parameter.regMap.indexWidth, parameter.regMap.dataWidth)))
+  val rsp          = Aligned(Decoupled(new RegMapResponse(parameter.regMap.dataWidth, parameter.regMap.reportError)))
+  val status       = Flipped(Bits(parameter.status.width))
+  val sampleReady  = Aligned(Bool())
+  val sampleValid  = Flipped(Bool())
+  val sampleData   = Flipped(Bits(parameter.sample.width))
+
+class RegMapReadProbe(parameter: RegMapReadParameter) extends DVBundle[RegMapReadParameter, RegMapReadLayers](parameter)
+
+@generator
+object RegMapRead extends Generator[RegMapReadParameter, RegMapReadLayers, RegMapReadIO, RegMapReadProbe]:
+  override def moduleName(parameter: RegMapReadParameter): String = "RegMapRead"
+
+  def architecture(parameter: RegMapReadParameter) =
+    val io           = summon[Interface[RegMapReadIO]]
+    given ClockScope = ClockScope.posedge(io.clock)
+    given ResetScope = ResetScope.syncActiveHigh(io.reset)
+
+    parameter.regMap(io.req, io.rsp)(
+      parameter.status.read(io.status),
+      parameter.sample.read(io.sampleReady, io.sampleValid, io.sampleData)
+    )
+
+    def word(field: Referable[Bits]): Referable[Bits] =
+      BigInt(0).U(parameter.regMap.dataWidth - field.width).asBits ## field
+    def acceptedRead(wordIndex: Int): Referable[Bool] =
+      io.req.valid & io.req.ready & io.req.bits.read &
+        (io.req.bits.index === BigInt(wordIndex).U(parameter.regMap.indexWidth))
+    val lane0         = io.req.bits.mask.bit(0)
+    val sampleFire    = io.sampleReady & io.sampleValid
+    val responseError = io.rsp.bits.error.get
+    val responseRead  = io.rsp.valid & io.rsp.bits.read
+
+    // Previous cycle.
+    val wasStalled     = RegInit(false.B)
+    val heldRead       = Reg(Bool())
+    val heldData       = Reg(Bits(parameter.regMap.dataWidth))
+    val heldError      = Reg(Bool())
+    val statusAccepted = RegInit(false.B)
+    val heldStatus     = Reg(Bits(parameter.status.width))
+    val sampleAccepted = RegInit(false.B)
+    val heldSample     = Reg(Bits(parameter.sample.width))
+    wasStalled     := io.rsp.valid & !io.rsp.ready
+    heldRead       := io.rsp.bits.read
+    heldData       := io.rsp.bits.data
+    heldError      := responseError
+    statusAccepted := acceptedRead(0)
+    heldStatus     := io.status
+    sampleAccepted := sampleFire
+    heldSample     := io.sampleData
+
+    val responseStable  = !wasStalled | (
+      io.rsp.valid & (io.rsp.bits.read === heldRead) & (io.rsp.bits.data === heldData) & (responseError === heldError)
+    )
+    val statusDelivered = !statusAccepted | (responseRead & (io.rsp.bits.data === word(heldStatus)))
+    val sampleExact     = sampleFire === (acceptedRead(1) & lane0)
+    val sampleDelivered = !sampleAccepted | (responseRead & (io.rsp.bits.data === word(heldSample)))
+
+    Contract((responseStable, statusDelivered, sampleExact, sampleDelivered)):
+      case (responseStable, statusDelivered, sampleExact, sampleDelivered) =>
+        Ensure(responseStable.I)
+        Ensure(statusDelivered.I)
+        Ensure(sampleExact.I)
+        Ensure(sampleDelivered.I)
+
+case class RegMapWriteParameter() extends Parameter:
+  val command    = RegField("command", 8).writeReadyValid
+  val ctrl       = RegField("ctrl", 8).writeValue
+  val verification = Layer("Verification")
+  val regMap     = RegMapDefinition(
+    indexWidth = 6,
+    dataWidth = 32,
+    queueEntries = 1,
+    reportError = true,
+    assertionLayer = verification
+  )(
+    0x00 -> Seq(command),
+    0x04 -> Seq(ctrl)
+  )
+
+given upickle.default.ReadWriter[RegMapWriteParameter] = upickle.default.macroRW
+
+class RegMapWriteLayers(parameter: RegMapWriteParameter) extends LayerInterface(parameter):
+  def layers = Seq(parameter.verification)
+
+class RegMapWriteIO(parameter: RegMapWriteParameter) extends HWBundle(parameter):
+  val clock        = Flipped(Clock())
+  val reset        = Flipped(Reset())
+  val req          = Flipped(Decoupled(new RegMapRequest(parameter.regMap.indexWidth, parameter.regMap.dataWidth)))
+  val rsp          = Aligned(Decoupled(new RegMapResponse(parameter.regMap.dataWidth, parameter.regMap.reportError)))
+  val commandReady = Flipped(Bool())
+  val commandValid = Aligned(Bool())
+  val commandData  = Aligned(Bits(parameter.command.width))
+
+class RegMapWriteProbe(parameter: RegMapWriteParameter)
+    extends DVBundle[RegMapWriteParameter, RegMapWriteLayers](parameter)
+
+@generator
+object RegMapWrite extends Generator[RegMapWriteParameter, RegMapWriteLayers, RegMapWriteIO, RegMapWriteProbe]:
+  override def moduleName(parameter: RegMapWriteParameter): String = "RegMapWrite"
+
+  def architecture(parameter: RegMapWriteParameter) =
+    val io           = summon[Interface[RegMapWriteIO]]
+    given ClockScope = ClockScope.posedge(io.clock)
+    given ResetScope = ResetScope.syncActiveHigh(io.reset)
+
+    val ctrl = RegInit(BigInt(0).U(parameter.ctrl.width).asBits)
+
+    parameter.regMap(io.req, io.rsp)(
+      parameter.command.write(io.commandReady, io.commandValid, io.commandData),
+      parameter.ctrl.write(ctrl)
+    )
+
+    def acceptedWrite(wordIndex: Int): Referable[Bool] =
+      io.req.valid & io.req.ready & !io.req.bits.read &
+        (io.req.bits.index === BigInt(wordIndex).U(parameter.regMap.indexWidth))
+    val lane0       = io.req.bits.mask.bit(0)
+    val writeData   = io.req.bits.data.bits(parameter.ctrl.width - 1, 0)
+    val commandFire = io.commandValid & io.commandReady
+
+    // Previous cycle.
+    val previousReset     = Reg(Bool())
+    val requestWasStalled = RegInit(false.B)
+    val heldRequestRead   = Reg(Bool())
+    val heldRequestIndex  = Reg(UInt(parameter.regMap.indexWidth))
+    val heldRequestData   = Reg(Bits(parameter.regMap.dataWidth))
+    val heldRequestMask   = Reg(Bits(parameter.regMap.dataWidth / 8))
+    val commandWasStalled = RegInit(false.B)
+    val heldCommandData   = Reg(Bits(parameter.command.width))
+    val writeAccepted     = RegInit(false.B)
+    val ctrlWritten       = RegInit(false.B)
+    val heldWriteData     = Reg(Bits(parameter.ctrl.width))
+    val heldCtrl          = Reg(Bits(parameter.ctrl.width))
+    previousReset     := io.reset.asBool
+    requestWasStalled := io.req.valid & !io.req.ready
+    heldRequestRead   := io.req.bits.read
+    heldRequestIndex  := io.req.bits.index
+    heldRequestData   := io.req.bits.data
+    heldRequestMask   := io.req.bits.mask
+    commandWasStalled := io.commandValid & !io.commandReady
+    heldCommandData   := io.commandData
+    writeAccepted     := io.req.valid & io.req.ready & !io.req.bits.read
+    ctrlWritten       := acceptedWrite(1) & lane0
+    heldWriteData     := writeData
+    heldCtrl          := ctrl
+
+    val requestStable  = !requestWasStalled | (
+      io.req.valid & (io.req.bits.read === heldRequestRead) & (io.req.bits.index === heldRequestIndex) &
+        (io.req.bits.data === heldRequestData) & (io.req.bits.mask === heldRequestMask)
+    )
+    val commandStable  = !commandWasStalled | (io.commandValid & (io.commandData === heldCommandData))
+    val commandExact   =
+      (commandFire === (acceptedWrite(0) & lane0)) & (!commandFire | (io.commandData === writeData))
+    val writeAnswered  = !writeAccepted | (io.rsp.valid & !io.rsp.bits.read)
+    val ctrlUpdated    = !ctrlWritten | (ctrl === heldWriteData)
+    val ctrlHeld       = previousReset | ctrlWritten | (ctrl === heldCtrl)
+
+    Contract((requestStable, commandStable, commandExact, writeAnswered, ctrlUpdated, ctrlHeld)):
+      case (requestStable, commandStable, commandExact, writeAnswered, ctrlUpdated, ctrlHeld) =>
+        Require(requestStable.I)
+        Ensure(commandStable.I)
+        Ensure(commandExact.I)
+        Ensure(writeAnswered.I)
+        Ensure(ctrlUpdated.I)
+        Ensure(ctrlHeld.I)

--- a/stdlib/src/mmio/RegField.scala
+++ b/stdlib/src/mmio/RegField.scala
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.stdlib.mmio
+
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+
+sealed trait RegRead
+
+sealed trait ValueRead extends RegRead:
+  final def apply(
+    data: Referable[Bits]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedValueRead(ValueRead.this, data)
+
+sealed trait ReadyValidRead extends RegRead:
+  final def apply(
+    ready: Referable[Bool] & Writable[Bool],
+    valid: Referable[Bool],
+    data:  Referable[Bits]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedReadyValidRead(ReadyValidRead.this, ready, valid, data)
+
+sealed trait RequestResponseRead extends RegRead:
+  final def apply(
+    requestReady:  Referable[Bool],
+    requestValid:  Referable[Bool] & Writable[Bool],
+    responseReady: Referable[Bool] & Writable[Bool],
+    responseValid: Referable[Bool],
+    data:          Referable[Bits]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedRequestResponseRead(
+      RequestResponseRead.this,
+      requestReady,
+      requestValid,
+      responseReady,
+      responseValid,
+      data
+    )
+
+sealed trait RegWrite
+
+sealed trait ValueWrite extends RegWrite:
+  final def apply(
+    data: Referable[Bits] & Writable[Bits]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedValueWrite(ValueWrite.this, data)
+
+sealed trait ReadyValidWrite extends RegWrite:
+  final def apply(
+    ready: Referable[Bool],
+    valid: Referable[Bool] & Writable[Bool],
+    data:  Referable[Bits] & Writable[Bits]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedReadyValidWrite(ReadyValidWrite.this, ready, valid, data)
+
+sealed trait RequestResponseWrite extends RegWrite:
+  final def apply(
+    requestReady:  Referable[Bool],
+    requestValid:  Referable[Bool] & Writable[Bool],
+    requestData:   Referable[Bits] & Writable[Bits],
+    responseReady: Referable[Bool] & Writable[Bool],
+    responseValid: Referable[Bool]
+  )(
+    using InstanceContext
+  ): AppliedRegAccess =
+    AppliedRequestResponseWrite(
+      RequestResponseWrite.this,
+      requestReady,
+      requestValid,
+      requestData,
+      responseReady,
+      responseValid
+    )
+
+final case class ValueReadDefinition()           extends ValueRead
+final case class ReadyValidReadDefinition()      extends ReadyValidRead
+final case class RequestResponseReadDefinition() extends RequestResponseRead
+
+final case class ValueWriteDefinition()           extends ValueWrite
+final case class ReadyValidWriteDefinition()      extends ReadyValidWrite
+final case class RequestResponseWriteDefinition() extends RequestResponseWrite
+
+sealed trait RegFieldDefinition:
+  def name:  String
+  def width: Int
+
+  protected final def requireValidWidth(): Unit =
+    require(width > 0, s"field $name width must be positive, not $width")
+
+sealed trait RegReadDefinition extends RegFieldDefinition:
+  def read: RegRead
+
+sealed trait RegWriteDefinition extends RegFieldDefinition:
+  def write: RegWrite
+
+final case class ReservedFieldDefinition(name: String, width: Int) extends RegFieldDefinition:
+  requireValidWidth()
+
+final case class ReadFieldDefinition[R <: RegRead](name: String, width: Int, read: R)
+    extends RegFieldDefinition
+    with RegReadDefinition:
+  requireValidWidth()
+
+  def writeValue: ReadWriteFieldDefinition[R, ValueWriteDefinition] =
+    ReadWriteFieldDefinition(name, width, read, ValueWriteDefinition())
+
+  def writeReadyValid: ReadWriteFieldDefinition[R, ReadyValidWriteDefinition] =
+    ReadWriteFieldDefinition(name, width, read, ReadyValidWriteDefinition())
+
+  def writeRequestResponse: ReadWriteFieldDefinition[R, RequestResponseWriteDefinition] =
+    ReadWriteFieldDefinition(name, width, read, RequestResponseWriteDefinition())
+
+final case class WriteFieldDefinition[W <: RegWrite](name: String, width: Int, write: W)
+    extends RegFieldDefinition
+    with RegWriteDefinition:
+  requireValidWidth()
+
+final case class ReadWriteFieldDefinition[R <: RegRead, W <: RegWrite](
+  name:  String,
+  width: Int,
+  read:  R,
+  write: W)
+    extends RegFieldDefinition
+    with RegReadDefinition
+    with RegWriteDefinition:
+  requireValidWidth()
+
+final case class RegFieldBuilder private[mmio] (name: String, width: Int):
+  require(width > 0, s"field $name width must be positive, not $width")
+
+  def readValue: ReadFieldDefinition[ValueReadDefinition] =
+    ReadFieldDefinition(name, width, ValueReadDefinition())
+
+  def readReadyValid: ReadFieldDefinition[ReadyValidReadDefinition] =
+    ReadFieldDefinition(name, width, ReadyValidReadDefinition())
+
+  def readRequestResponse: ReadFieldDefinition[RequestResponseReadDefinition] =
+    ReadFieldDefinition(name, width, RequestResponseReadDefinition())
+
+  def writeValue: WriteFieldDefinition[ValueWriteDefinition] =
+    WriteFieldDefinition(name, width, ValueWriteDefinition())
+
+  def writeReadyValid: WriteFieldDefinition[ReadyValidWriteDefinition] =
+    WriteFieldDefinition(name, width, ReadyValidWriteDefinition())
+
+  def writeRequestResponse: WriteFieldDefinition[RequestResponseWriteDefinition] =
+    WriteFieldDefinition(name, width, RequestResponseWriteDefinition())
+
+sealed trait AppliedRegAccess
+
+private[mmio] sealed trait AppliedRegReadAccess extends AppliedRegAccess:
+  def definition: RegRead
+
+private[mmio] sealed trait AppliedRegWriteAccess extends AppliedRegAccess:
+  def definition: RegWrite
+
+private[mmio] final case class AppliedValueRead(
+  definition: RegRead,
+  data:       Referable[Bits])
+    extends AppliedRegReadAccess
+
+private[mmio] final case class AppliedReadyValidRead(
+  definition: RegRead,
+  ready:      Referable[Bool] & Writable[Bool],
+  valid:      Referable[Bool],
+  data:       Referable[Bits])
+    extends AppliedRegReadAccess
+
+private[mmio] final case class AppliedRequestResponseRead(
+  definition:    RegRead,
+  requestReady:  Referable[Bool],
+  requestValid:  Referable[Bool] & Writable[Bool],
+  responseReady: Referable[Bool] & Writable[Bool],
+  responseValid: Referable[Bool],
+  data:          Referable[Bits])
+    extends AppliedRegReadAccess
+
+private[mmio] final case class AppliedValueWrite(
+  definition: RegWrite,
+  data:       Referable[Bits] & Writable[Bits])
+    extends AppliedRegWriteAccess
+
+private[mmio] final case class AppliedReadyValidWrite(
+  definition: RegWrite,
+  ready:      Referable[Bool],
+  valid:      Referable[Bool] & Writable[Bool],
+  data:       Referable[Bits] & Writable[Bits])
+    extends AppliedRegWriteAccess
+
+private[mmio] final case class AppliedRequestResponseWrite(
+  definition:    RegWrite,
+  requestReady:  Referable[Bool],
+  requestValid:  Referable[Bool] & Writable[Bool],
+  requestData:   Referable[Bits] & Writable[Bits],
+  responseReady: Referable[Bool] & Writable[Bool],
+  responseValid: Referable[Bool])
+    extends AppliedRegWriteAccess
+
+object RegField:
+  def apply(name: String, width: Int): RegFieldBuilder =
+    RegFieldBuilder(name, width)
+
+  def reserved(name: String, width: Int): ReservedFieldDefinition =
+    ReservedFieldDefinition(name, width)

--- a/stdlib/src/mmio/RegMapDefinition.scala
+++ b/stdlib/src/mmio/RegMapDefinition.scala
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.stdlib.mmio
+
+import me.jiuyang.stdlib.*
+import me.jiuyang.stdlib.queue.*
+import me.jiuyang.stdlib.queue.default.given
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.ltltpe.*
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+
+import org.llvm.circt.scalalib.dialect.firrtl.operation.{RegResetPolarity, RegResetType}
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
+
+import java.lang.foreign.Arena
+
+final case class RegMapRegister(byteOffset: BigInt, fields: Seq[RegFieldDefinition])
+
+final case class RegMapDefinition(
+  indexWidth:     Int,
+  dataWidth:      Int,
+  queueEntries:   Int,
+  reportError:    Boolean,
+  assertionLayer: Layer,
+  registers: Seq[RegMapRegister]):
+  require(indexWidth > 0, s"indexWidth must be positive, not $indexWidth")
+  require(dataWidth > 0 && dataWidth % 8 == 0, s"dataWidth must be a positive multiple of 8, not $dataWidth")
+  require(queueEntries >= 0, s"queueEntries must not be negative, not $queueEntries")
+  private case class FieldRange(definition: RegFieldDefinition, low: BigInt, high: BigInt):
+    val word = low / dataWidth
+
+  private val ranges = registers.flatMap: register =>
+    require(register.byteOffset >= 0, s"register byte offset ${register.byteOffset} must not be negative")
+    var bitOffset = register.byteOffset * 8
+    register.fields.map: field =>
+      val range = FieldRange(field, bitOffset, bitOffset + field.width)
+      bitOffset = range.high
+      range
+
+  require(ranges.nonEmpty, "RegMap must contain at least one field mapping")
+
+  private val sortedRanges = ranges.sortBy(_.low)
+  sortedRanges
+    .zip(sortedRanges.drop(1))
+    .foreach:     (left, right) =>
+      require(left.high <= right.low, s"register map overlaps at bit ${right.low}")
+  ranges.foreach: range =>
+    require(range.low / dataWidth == (range.high - 1) / dataWidth, s"field ${range.definition.name} crosses a word")
+    require(range.word.bitLength <= indexWidth, s"field ${range.definition.name} index does not fit")
+
+  private val definitions   = registers.flatMap(_.fields)
+  private val requiresQueue =
+    definitions.collect { case field: RegReadDefinition => field }.exists(_.read.isInstanceOf[RequestResponseRead]) ||
+      definitions.collect { case field: RegWriteDefinition => field }
+        .exists(_.write.isInstanceOf[RequestResponseWrite])
+  require(!requiresQueue || queueEntries > 0, "request-response fields require a non-zero queueEntries")
+  require(
+    definitions.indices.forall(i => definitions.indices.forall(j => i == j || !(definitions(i) eq definitions(j)))),
+    "a field definition must not appear more than once"
+  )
+  require(definitions.map(_.name).distinct.size == definitions.size, "register field names must be distinct")
+
+  def apply(
+    req:      Referable[DecoupledIO[RegMapRequest]] & Writable[DecoupledIO[RegMapRequest]],
+    rsp:      Referable[DecoupledIO[RegMapResponse]] & Writable[DecoupledIO[RegMapResponse]]
+  )(accesses: AppliedRegAccess*
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext,
+    ClockScope,
+    ResetScope,
+    Seq[LayerTree]
+  ): Unit =
+    case class Layout(definition: RegFieldDefinition, wordIndex: BigInt, bitOffset: Int)
+    case class FieldCircuit(
+      layout:           Layout,
+      readInputValid:   Wire[Bool],
+      readOutputReady:  Wire[Bool],
+      readInputReady:   Referable[Bool],
+      readOutputValid:  Referable[Bool],
+      readFrontData:    Referable[Bits],
+      readBackData:     Referable[Bits],
+      writeInputValid:  Wire[Bool],
+      writeOutputReady: Wire[Bool],
+      writeInputReady:  Referable[Bool],
+      writeOutputValid: Referable[Bool])
+
+    require(req.bits.getType.indexWidth == indexWidth, "request index width does not match RegMap")
+    require(req.bits.getType.dataWidth == dataWidth, "request data width does not match RegMap")
+    require(rsp.bits.getType.dataWidth == dataWidth, "response data width does not match RegMap")
+    require(rsp.bits.getType.reportError == reportError, "response error shape does not match RegMap")
+
+    val readDefinitions  = definitions.collect { case field: RegReadDefinition => field }
+    val writeDefinitions = definitions.collect { case field: RegWriteDefinition => field }
+    val appliedReads     = accesses.collect { case access: AppliedRegReadAccess => access }
+    val appliedWrites    = accesses.collect { case access: AppliedRegWriteAccess => access }
+
+    require(
+      accesses.size == readDefinitions.size + writeDefinitions.size,
+      "every register read and write capability must be applied exactly once"
+    )
+    readDefinitions.foreach:  field =>
+      require(
+        appliedReads.count(applied => applied.definition eq field.read) == 1,
+        s"field ${field.name} read capability must be applied exactly once"
+      )
+    writeDefinitions.foreach: field =>
+      require(
+        appliedWrites.count(applied => applied.definition eq field.write) == 1,
+        s"field ${field.name} write capability must be applied exactly once"
+      )
+    appliedReads.foreach:     applied =>
+      require(
+        readDefinitions.exists(field => field.read eq applied.definition),
+        "applied read capability is not part of this RegMap"
+      )
+    appliedWrites.foreach:    applied =>
+      require(
+        writeDefinitions.exists(field => field.write eq applied.definition),
+        "applied write capability is not part of this RegMap"
+      )
+
+    val flatLayouts = registers.flatMap: register =>
+      var absoluteBit = register.byteOffset * 8
+      register.fields.map: field =>
+        val layout = Layout(field, absoluteBit / dataWidth, (absoluteBit % dataWidth).toInt)
+        absoluteBit += field.width
+        layout
+    val layouts     = flatLayouts.groupBy(_.wordIndex).toSeq.sortBy(_._1)
+
+    // Read data is sampled when the request is accepted and travels with the queue entry.
+    val frontReadWord = Wire(Bits(dataWidth))
+
+    val queue = Option.when(queueEntries > 0):
+      val resetScope = summon[ResetScope]
+      val instance   = Queue(
+        QueueParameter(
+          req.bits.getType,
+          entries = queueEntries,
+          asyncReset = resetScope.resetType == RegResetType.AsyncReset
+        )
+      )
+      instance.clock          := summon[ClockScope].clock
+      instance.reset          := (
+        if resetScope.resetPolarity == RegResetPolarity.PosReset then resetScope.reset
+        else (!resetScope.reset.asBool).asReset
+      )
+      instance.enq.bits.read  := req.bits.read
+      instance.enq.bits.index := req.bits.index
+      instance.enq.bits.mask  := req.bits.mask
+      instance.enq.bits.data  := frontReadWord
+      instance
+
+    val frontReady = Wire(Bool())
+    val backValid  = Wire(Bool())
+    val backRead:     Referable[Bool] = queue.map(_.deq.bits.read: Referable[Bool]).getOrElse(req.bits.read)
+    val backIndex:    Referable[UInt] = queue.map(_.deq.bits.index: Referable[UInt]).getOrElse(req.bits.index)
+    val backReadWord: Referable[Bits] = queue.map(_.deq.bits.data: Referable[Bits]).getOrElse(frontReadWord)
+    val backMask:     Referable[Bits] = queue.map(_.deq.bits.mask: Referable[Bits]).getOrElse(req.bits.mask)
+
+    def reduceOthers(
+      values: Seq[Referable[Bool]]
+    ): (Seq[Referable[Bool]], Referable[Bool]) =
+      if values.size <= 1 then (Seq.fill(values.size)(true.B), values.headOption.getOrElse(true.B))
+      else if values.size <= 3 then
+        (
+          values.indices.map: index =>
+            values.take(index).appendedAll(values.drop(index + 1)).reduce(_ & _),
+          values.reduce(_ & _)
+        )
+      else
+        val (groupOthers, all) = reduceOthers(values.grouped(2).map(_.reduce(_ & _)).toSeq)
+        val others             = values.indices.map: index =>
+          val siblingIndex = index ^ 1
+          if siblingIndex < values.size then values(siblingIndex) & groupOthers(index / 2)
+          else groupOthers(index / 2)
+        (others, all)
+
+    def readMask(
+      layout: Layout,
+      mask:   Referable[Bits]
+    )(
+      using Block
+    ): Referable[Bool] =
+      val firstLane = layout.bitOffset / 8
+      val lastLane  = (layout.bitOffset + layout.definition.width - 1) / 8
+      (firstLane to lastLane).map(mask.bit).reduce(_ | _)
+
+    def writeMask(
+      layout: Layout,
+      mask:   Referable[Bits]
+    )(
+      using Block
+    ): Referable[Bool] =
+      val firstLane = layout.bitOffset / 8
+      val lastLane  = (layout.bitOffset + layout.definition.width - 1) / 8
+      (firstLane to lastLane).map(mask.bit).reduce(_ & _)
+
+    val circuits = layouts.map: (wordIndex, wordLayouts) =>
+      val fields = wordLayouts.map: layout =>
+        val readInputValid                                                 = Wire(Bool())
+        val readOutputReady                                                = Wire(Bool())
+        val writeInputValid                                                = Wire(Bool())
+        val writeOutputReady                                               = Wire(Bool())
+        val high                                                           = layout.bitOffset + layout.definition.width - 1
+        val frontData                                                      = req.bits.data.bits(high, layout.bitOffset)
+        val heldReadData                                                   = backReadWord.bits(high, layout.bitOffset)
+        val zeroData                                                       = BigInt(0).B(layout.definition.width)
+        val readAccess                                                     = layout.definition match
+          case definition: RegReadDefinition =>
+            appliedReads.find(applied => applied.definition eq definition.read)
+          case _ => None
+        val readSignals: (Referable[Bool], Referable[Bool], Referable[Bits], Referable[Bits]) = readAccess match
+          case Some(AppliedValueRead(_, data))                    =>
+            require(
+              data.width == layout.definition.width,
+              s"field ${layout.definition.name} read width does not match"
+            )
+            (true.B, true.B, data, heldReadData)
+          case Some(AppliedReadyValidRead(_, ready, valid, data)) =>
+            require(
+              data.width == layout.definition.width,
+              s"field ${layout.definition.name} read width does not match"
+            )
+            ready := readInputValid
+            (valid, true.B, data, heldReadData)
+          case Some(
+                AppliedRequestResponseRead(_, requestReady, requestValid, responseReady, responseValid, data)
+              ) =>
+            require(
+              data.width == layout.definition.width,
+              s"field ${layout.definition.name} read width does not match"
+            )
+            requestValid  := readInputValid
+            responseReady := readOutputReady
+            (requestReady, responseValid, zeroData, data)
+          case None                                               =>
+            (true.B, true.B, zeroData, zeroData)
+        val (readInputReady, readOutputValid, readFrontData, readBackData) = readSignals
+
+        val writeAccess                         = layout.definition match
+          case definition: RegWriteDefinition =>
+            appliedWrites.find(applied => applied.definition eq definition.write)
+          case _ => None
+        val writeSignals: (Referable[Bool], Referable[Bool]) = writeAccess match
+          case Some(AppliedValueWrite(_, data))                    =>
+            require(
+              data.width == layout.definition.width,
+              s"field ${layout.definition.name} write width does not match"
+            )
+            when(writeInputValid):
+              data := frontData
+            (true.B, true.B)
+          case Some(AppliedReadyValidWrite(_, ready, valid, data)) =>
+            require(
+              data.width == layout.definition.width,
+              s"field ${layout.definition.name} write width does not match"
+            )
+            valid := writeInputValid
+            data  := frontData
+            (ready, true.B)
+          case Some(
+                AppliedRequestResponseWrite(
+                  _,
+                  requestReady,
+                  requestValid,
+                  requestData,
+                  responseReady,
+                  responseValid
+                )
+              ) =>
+            require(
+              requestData.width == layout.definition.width,
+              s"field ${layout.definition.name} write width does not match"
+            )
+            requestValid  := writeInputValid
+            requestData   := frontData
+            responseReady := writeOutputReady
+            (requestReady, responseValid)
+          case None                                                =>
+            (true.B, true.B)
+        val (writeInputReady, writeOutputValid) = writeSignals
+        FieldCircuit(
+          layout,
+          readInputValid,
+          readOutputReady,
+          readInputReady,
+          readOutputValid,
+          readFrontData,
+          readBackData,
+          writeInputValid,
+          writeOutputReady,
+          writeInputReady,
+          writeOutputValid
+        )
+      wordIndex -> fields
+
+    def inputHit(
+      index:     Referable[UInt],
+      wordIndex: BigInt
+    )(
+      using Block
+    ): Referable[Bool] =
+      index === wordIndex.U(indexWidth)
+
+    val flows = circuits.map: (wordIndex, fields) =>
+      val readInputMasks   = fields.map(field => readMask(field.layout, req.bits.mask))
+      val writeInputMasks  = fields.map(field => writeMask(field.layout, req.bits.mask))
+      val readOutputMasks  = fields.map(field => readMask(field.layout, backMask))
+      val writeOutputMasks = fields.map(field => writeMask(field.layout, backMask))
+
+      val (otherReadInputReady, readInputReady)     = reduceOthers(
+        fields.zip(readInputMasks).map((field, mask) => mask ? (field.readInputReady, true.B))
+      )
+      val (otherWriteInputReady, writeInputReady)   = reduceOthers(
+        fields.zip(writeInputMasks).map((field, mask) => mask ? (field.writeInputReady, true.B))
+      )
+      val (otherReadOutputValid, readOutputValid)   = reduceOthers(
+        fields.zip(readOutputMasks).map((field, mask) => mask ? (field.readOutputValid, true.B))
+      )
+      val (otherWriteOutputValid, writeOutputValid) = reduceOthers(
+        fields.zip(writeOutputMasks).map((field, mask) => mask ? (field.writeOutputValid, true.B))
+      )
+
+      fields.indices.foreach: index =>
+        val field = fields(index)
+        field.readInputValid   :=
+          req.valid & frontReady & inputHit(req.bits.index, wordIndex) & req.bits.read & readInputMasks(
+            index
+          ) & otherReadInputReady(index)
+        field.writeInputValid  :=
+          req.valid & frontReady & inputHit(req.bits.index, wordIndex) & !req.bits.read & writeInputMasks(
+            index
+          ) & otherWriteInputReady(index)
+        field.readOutputReady  :=
+          backValid & inputHit(backIndex, wordIndex) & backRead & readOutputMasks(index) & rsp.ready &
+            otherReadOutputValid(index)
+        field.writeOutputReady :=
+          backValid & inputHit(backIndex, wordIndex) & !backRead & writeOutputMasks(index) & rsp.ready &
+            otherWriteOutputValid(index)
+
+      (wordIndex, readInputReady, writeInputReady, readOutputValid, writeOutputValid)
+
+    val selectedInputReady = flows.foldLeft(true.B: Referable[Bool]):
+      case (default, (wordIndex, readReady, writeReady, _, _)) =>
+        inputHit(req.bits.index, wordIndex) ? (req.bits.read ? (readReady, writeReady), default)
+
+    val selectedOutputValid = flows.foldLeft(true.B: Referable[Bool]):
+      case (default, (wordIndex, _, _, readValid, writeValid)) =>
+        inputHit(backIndex, wordIndex) ? (backRead ? (readValid, writeValid), default)
+
+    queue match
+      case Some(instance) =>
+        frontReady         := instance.enq.ready
+        backValid          := instance.deq.valid
+        instance.enq.valid := req.valid & selectedInputReady
+        instance.deq.ready := rsp.ready & selectedOutputValid
+      case None           =>
+        frontReady := rsp.ready & selectedOutputValid
+        backValid  := req.valid & selectedInputReady
+
+    val requestMapped = circuits
+      .map((wordIndex, _) => inputHit(backIndex, wordIndex))
+      .reduceOption(_ | _)
+      .getOrElse(false.B)
+    req.ready     := frontReady & selectedInputReady
+    rsp.valid     := backValid & selectedOutputValid
+    rsp.bits.read := backRead
+    rsp.bits.error.foreach(_ := !requestMapped)
+
+    def assembleWord(fields: Seq[FieldCircuit], data: FieldCircuit => Referable[Bits]): Referable[Bits] =
+      val segments               = fields
+        .sortBy(_.layout.bitOffset)
+        .map(field => field.layout.bitOffset -> data(field))
+      val withPadding            = segments.foldLeft((0, Seq.empty[Referable[Bits]])):
+        case ((nextBit, result), (bitOffset, data)) =>
+          val gap = Option.when(bitOffset > nextBit)(BigInt(0).U(bitOffset - nextBit).asBits).toSeq
+          (bitOffset + data.width, result ++ gap :+ data)
+      val (usedWidth, lowToHigh) = withPadding
+      val highPadding            = Option
+        .when(usedWidth < dataWidth)(BigInt(0).U(dataWidth - usedWidth).asBits)
+        .toSeq
+      (highPadding ++ lowToHigh.reverse).reduce(_ ## _)
+
+    frontReadWord := circuits.foldLeft(BigInt(0).U(dataWidth).asBits: Referable[Bits]):
+      case (default, (wordIndex, fields)) =>
+        inputHit(req.bits.index, wordIndex) ? (assembleWord(fields, _.readFrontData), default)
+
+    rsp.bits.data := circuits.foldLeft(BigInt(0).U(dataWidth).asBits: Referable[Bits]):
+      case (default, (wordIndex, fields)) =>
+        inputHit(backIndex, wordIndex) ? (assembleWord(fields, _.readBackData), default)
+
+    layer(assertionLayer.name):
+      val requestHeld      = RegInit(false.B)
+      val heldRequestRead  = Reg(Bool())
+      val heldRequestIndex = Reg(UInt(indexWidth))
+      val heldRequestData  = Reg(Bits(dataWidth))
+      val heldRequestMask  = Reg(Bits(dataWidth / 8))
+
+      val beginRequestHold = req.valid & !req.ready & !requestHeld
+      requestHeld      := req.ready ? (false.B, beginRequestHold ? (true.B, requestHeld))
+      heldRequestRead  := beginRequestHold ? (req.bits.read, heldRequestRead)
+      heldRequestIndex := beginRequestHold ? (req.bits.index, heldRequestIndex)
+      heldRequestData  := beginRequestHold ? (req.bits.data, heldRequestData)
+      heldRequestMask  := beginRequestHold ? (req.bits.mask, heldRequestMask)
+
+      Assert(req.valid.I, requestHeld, "regmap_request_valid_held")
+      Assert((req.bits.read === heldRequestRead).I, requestHeld, "regmap_request_read_stable")
+      Assert((req.bits.index === heldRequestIndex).I, requestHeld, "regmap_request_index_stable")
+      Assert((req.bits.data === heldRequestData).I, requestHeld, "regmap_request_data_stable")
+      Assert((req.bits.mask === heldRequestMask).I, requestHeld, "regmap_request_mask_stable")
+
+      val responseHeld      = RegInit(false.B)
+      val heldResponseRead  = Reg(Bool())
+      val heldResponseData  = Reg(Bits(dataWidth))
+      val heldResponseError = rsp.bits.error.map(_ => Reg(Bool()))
+
+      val beginResponseHold = rsp.valid & !rsp.ready & !responseHeld
+      responseHeld     := rsp.ready ? (false.B, beginResponseHold ? (true.B, responseHeld))
+      heldResponseRead := beginResponseHold ? (rsp.bits.read, heldResponseRead)
+      heldResponseData := beginResponseHold ? (rsp.bits.data, heldResponseData)
+      heldResponseError
+        .zip(rsp.bits.error)
+        .foreach: (held, error) =>
+          held := beginResponseHold ? (error, held)
+
+      Assert(rsp.valid.I, responseHeld, "regmap_response_valid_held")
+      Assert((rsp.bits.read === heldResponseRead).I, responseHeld, "regmap_response_read_stable")
+      Assert((rsp.bits.data === heldResponseData).I, responseHeld, "regmap_response_data_stable")
+      heldResponseError
+        .zip(rsp.bits.error)
+        .foreach: (held, error) =>
+          Assert((error === held).I, responseHeld, "regmap_response_error_stable")
+
+      val resetScope   = summon[ResetScope]
+      val active       =
+        if resetScope.resetPolarity == RegResetPolarity.PosReset then !resetScope.reset.asBool
+        else resetScope.reset.asBool
+      val requestFire  = req.valid & req.ready
+      val responseFire = rsp.valid & rsp.ready
+
+      Cover((requestFire & req.bits.read).I, active, "regmap_read_accept")
+      Cover((requestFire & !req.bits.read).I, active, "regmap_write_accept")
+      Cover((req.valid & !req.ready).I, active, "regmap_request_stall")
+      Cover((rsp.valid & !rsp.ready).I, active, "regmap_response_stall")
+      if queueEntries > 0 then Cover((requestFire & rsp.valid).I, active, "regmap_accept_with_response_pending")
+      rsp.bits.error.foreach(error => Cover((responseFire & error).I, active, "regmap_error_response"))
+
+      circuits.foreach: (wordIndex, fields) =>
+        fields.foreach: field =>
+          val name = field.layout.definition.name
+          field.layout.definition match
+            case definition: RegReadDefinition =>
+              Cover((field.readInputValid & field.readInputReady).I, active, s"regmap_${name}_read")
+              if definition.read.isInstanceOf[RequestResponseRead] then
+                Cover((field.readOutputReady & field.readOutputValid).I, active, s"regmap_${name}_read_response")
+            case _ => ()
+          field.layout.definition match
+            case definition: RegWriteDefinition =>
+              Cover((field.writeInputValid & field.writeInputReady).I, active, s"regmap_${name}_write")
+              if definition.write.isInstanceOf[RequestResponseWrite] then
+                Cover((field.writeOutputReady & field.writeOutputValid).I, active, s"regmap_${name}_write_response")
+              Cover(
+                (requestFire & !req.bits.read & inputHit(req.bits.index, wordIndex) & !writeMask(
+                  field.layout,
+                  req.bits.mask
+                )).I,
+                active,
+                s"regmap_${name}_write_masked_out"
+              )
+            case _ => ()
+
+object RegMapDefinition:
+  type Map = (Int, Seq[RegFieldDefinition])
+
+  def apply(
+    indexWidth:     Int,
+    dataWidth:      Int,
+    assertionLayer: Layer,
+    queueEntries:   Int = 0,
+    reportError:    Boolean = false
+  )(mapping:        Map*
+  ): RegMapDefinition =
+    RegMapDefinition(
+      indexWidth,
+      dataWidth,
+      queueEntries,
+      reportError,
+      assertionLayer,
+      mapping.map((offset, fields) => RegMapRegister(BigInt(offset), fields))
+    )

--- a/stdlib/src/mmio/RegMapIO.scala
+++ b/stdlib/src/mmio/RegMapIO.scala
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.stdlib.mmio
+
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.valuetpe.*
+
+class RegMapRequest(
+  val indexWidth: Int,
+  val dataWidth:  Int
+)(
+  using TypeImpl,
+  ConstructorApi)
+    extends Bundle:
+  require(indexWidth > 0, s"indexWidth must be positive, not $indexWidth")
+  require(dataWidth > 0 && dataWidth % 8 == 0, s"dataWidth must be a positive multiple of 8, not $dataWidth")
+
+  val read:  BundleField[Bool] = Aligned(summon[ConstructorApi].Bool())
+  val index: BundleField[UInt] = Aligned(summon[ConstructorApi].UInt(indexWidth))
+  val data:  BundleField[Bits] = Aligned(summon[ConstructorApi].Bits(dataWidth))
+  val mask:  BundleField[Bits] = Aligned(summon[ConstructorApi].Bits(dataWidth / 8))
+
+class RegMapResponse(
+  val dataWidth:   Int,
+  val reportError: Boolean
+)(
+  using TypeImpl,
+  ConstructorApi)
+    extends Bundle:
+  require(dataWidth > 0 && dataWidth % 8 == 0, s"dataWidth must be a positive multiple of 8, not $dataWidth")
+
+  val read:  BundleField[Bool]         = Aligned(summon[ConstructorApi].Bool())
+  val data:  BundleField[Bits]         = Aligned(summon[ConstructorApi].Bits(dataWidth))
+  val error: Option[BundleField[Bool]] = Option.when(reportError)(Aligned(summon[ConstructorApi].Bool()))

--- a/stdlib/src/mmio/examples/MinimalRegMap.scala
+++ b/stdlib/src/mmio/examples/MinimalRegMap.scala
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.stdlib.mmio.examples
+
+import me.jiuyang.stdlib.*
+import me.jiuyang.stdlib.mmio.*
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+
+case class MinimalRegMapParameter() extends Parameter:
+  val enable       = RegField("enable", 8).readValue.writeValue
+  val busy         = RegField("busy", 1).readValue
+  val busyReserved = RegField.reserved("busyReserved", 7)
+  val command      = RegField("command", 8).writeReadyValid
+  val snapshot     = RegField("snapshot", 1).readRequestResponse.writeValue
+  val verification = Layer("Verification")
+  val regMap       = RegMapDefinition(
+    indexWidth = 6,
+    dataWidth = 32,
+    queueEntries = 1,
+    reportError = true,
+    assertionLayer = verification
+  )(
+    0x00 -> Seq(enable),
+    0x04 -> Seq(busy, busyReserved),
+    0x08 -> Seq(command),
+    0x0c -> Seq(snapshot)
+  )
+
+given upickle.default.ReadWriter[MinimalRegMapParameter] = upickle.default.macroRW
+
+class MinimalRegMapLayers(parameter: MinimalRegMapParameter) extends LayerInterface(parameter):
+  def layers = Seq(parameter.regMap.assertionLayer)
+
+class MinimalRegMapIO(parameter: MinimalRegMapParameter) extends HWBundle(parameter):
+  val clock        = Flipped(Clock())
+  val reset        = Flipped(Reset())
+  val req          = Flipped(Decoupled(new RegMapRequest(parameter.regMap.indexWidth, parameter.regMap.dataWidth)))
+  val rsp          = Aligned(Decoupled(new RegMapResponse(parameter.regMap.dataWidth, parameter.regMap.reportError)))
+  val busy         = Flipped(Bool())
+  val enable       = Aligned(Bits(parameter.enable.width))
+  val commandReady = Flipped(Bool())
+  val commandValid = Aligned(Bool())
+  val commandData  = Aligned(Bits(parameter.command.width))
+
+class MinimalRegMapProbe(parameter: MinimalRegMapParameter)
+    extends DVBundle[MinimalRegMapParameter, MinimalRegMapLayers](parameter)
+
+@generator
+object MinimalRegMap
+    extends Generator[
+      MinimalRegMapParameter,
+      MinimalRegMapLayers,
+      MinimalRegMapIO,
+      MinimalRegMapProbe
+    ]:
+  def architecture(parameter: MinimalRegMapParameter) =
+    val io                    = summon[Interface[MinimalRegMapIO]]
+    given ClockScope          = ClockScope.posedge(io.clock)
+    given ResetScope          = ResetScope.syncActiveHigh(io.reset)
+    val enable                = RegInit(BigInt(0).U(parameter.enable.width).asBits)
+    val snapshotWritable      = RegInit(BigInt(0).U(parameter.snapshot.width).asBits)
+    val snapshotPending       = RegInit(false.B)
+    val snapshotData          = Reg(Bits(parameter.snapshot.width))
+    val snapshotRequestReady  = Wire(Bool())
+    val snapshotRequestValid  = Wire(Bool())
+    val snapshotResponseReady = Wire(Bool())
+    val snapshotResponseValid = Wire(Bool())
+    val snapshotInputFire     = snapshotRequestValid & snapshotRequestReady
+    val snapshotOutputFire    = snapshotResponseValid & snapshotResponseReady
+
+    snapshotPending       := snapshotInputFire ? (true.B, snapshotOutputFire ? (false.B, snapshotPending))
+    snapshotData          := snapshotInputFire ? (io.busy.asBits, snapshotData)
+    snapshotRequestReady  := !snapshotPending
+    snapshotResponseValid := snapshotPending
+
+    io.enable := enable
+    parameter.regMap(io.req, io.rsp)(
+      parameter.enable.read(enable),
+      parameter.enable.write(enable),
+      parameter.busy.read(io.busy.asBits),
+      parameter.command.write(io.commandReady, io.commandValid, io.commandData),
+      parameter.snapshot.read(
+        snapshotRequestReady,
+        snapshotRequestValid,
+        snapshotResponseReady,
+        snapshotResponseValid,
+        snapshotData
+      ),
+      parameter.snapshot.write(snapshotWritable)
+    )

--- a/stdlib/src/queue/Queue.scala
+++ b/stdlib/src/queue/Queue.scala
@@ -30,7 +30,7 @@ case class QueueParameter[D <: HardwareDataType](
   /** Assert `almostFull` when occupancy reaches `entries - almostFullLevel`. */
   almostFullLevel:  Int = 1)
     extends Parameter:
-  require(entries >= 2, "Queue entries must be at least 2")
+  require(entries >= 1, "Queue entries must be positive")
 
 /** Backend-independent decoupled Queue interface. */
 class QueueIO[D <: HardwareDataType](

--- a/stdlib/src/queue/default/SyncQueue.scala
+++ b/stdlib/src/queue/default/SyncQueue.scala
@@ -278,39 +278,67 @@ given QueueImpl with
     sourcecode.Name.Machine,
     InstanceContext
   ): Wire[QueueIO[D]] =
-    val io    = Wire(new QueueIO(parameter))
-    val queue = SyncQueue.instantiate(
-      SyncQueueParameter(
-        width = parameter.gen.width,
-        depth = parameter.entries,
-        almostEmptyLevel = parameter.almostEmptyLevel,
-        almostFullLevel = parameter.almostFullLevel,
-        stickyError = false,
-        enableDiagnostics = false,
-        asyncReset = parameter.asyncReset,
-        resetMem = parameter.resetMem
+    val io = Wire(new QueueIO(parameter))
+    if parameter.entries == 1 then
+      given ClockScope = ClockScope.posedge(io.clock)
+      given ResetScope =
+        if parameter.asyncReset then ResetScope.asyncActiveHigh(io.reset)
+        else ResetScope.syncActiveHigh(io.reset)
+
+      val full = RegInit(false.B)
+      val data =
+        if parameter.resetMem then RegInit(BigInt(0).U(parameter.gen.width).asBits)
+        else Reg(Bits(parameter.gen.width))
+
+      io.enq.ready := !full | (if parameter.pipe then io.deq.ready else false.B)
+      io.deq.valid := full | (if parameter.flow then io.enq.valid else false.B)
+
+      val enqueue = io.enq.valid & io.enq.ready
+      val dequeue = io.deq.valid & io.deq.ready
+      val bypass  = if parameter.flow then !full & dequeue else false.B
+      val store   = enqueue & !bypass
+
+      full := store | (full & !dequeue)
+      when(store):
+        data := io.enq.bits.asBits
+
+      val storedData = data.asType(io.deq.bits.getType)
+      io.deq.bits :<= (if parameter.flow then full ? (storedData, io.enq.bits) else storedData)
+      io.empty := !full
+      io.full  := full
+    else
+      val queue = SyncQueue.instantiate(
+        SyncQueueParameter(
+          width = parameter.gen.width,
+          depth = parameter.entries,
+          almostEmptyLevel = parameter.almostEmptyLevel,
+          almostFullLevel = parameter.almostFullLevel,
+          stickyError = false,
+          enableDiagnostics = false,
+          asyncReset = parameter.asyncReset,
+          resetMem = parameter.resetMem
+        )
       )
-    )
 
-    queue.io.clock       := io.clock
-    queue.io.resetN      := (!io.reset.asBool).asReset
-    queue.io.diagnosticN := true.B
-    queue.io.dataIn      := io.enq.bits.asBits.asUInt
+      queue.io.clock       := io.clock
+      queue.io.resetN      := (!io.reset.asBool).asReset
+      queue.io.diagnosticN := true.B
+      queue.io.dataIn      := io.enq.bits.asBits.asUInt
 
-    // `pipe` lets a same-cycle dequeue make room in a full queue. `flow` bypasses an empty queue without writing RAM.
-    io.enq.ready          := !queue.io.full | (if parameter.pipe then io.deq.ready else false.B)
-    queue.io.pushRequestN :=
-      !(io.enq.fire & (if parameter.flow then !(queue.io.empty & io.deq.ready) else true.B))
+      // `pipe` lets a same-cycle dequeue make room in a full queue. `flow` bypasses an empty queue without writing RAM.
+      io.enq.ready          := !queue.io.full | (if parameter.pipe then io.deq.ready else false.B)
+      queue.io.pushRequestN :=
+        !(io.enq.fire & (if parameter.flow then !(queue.io.empty & io.deq.ready) else true.B))
 
-    io.deq.valid         := !queue.io.empty | (if parameter.flow then io.enq.valid else false.B)
-    queue.io.popRequestN := !(io.deq.ready & !queue.io.empty)
-    val storedData = queue.io.dataOut.asBits.asType(io.deq.bits.getType)
-    io.deq.bits :<= (if parameter.flow then queue.io.empty ? (io.enq.bits, storedData) else storedData)
+      io.deq.valid         := !queue.io.empty | (if parameter.flow then io.enq.valid else false.B)
+      queue.io.popRequestN := !(io.deq.ready & !queue.io.empty)
+      val storedData = queue.io.dataOut.asBits.asType(io.deq.bits.getType)
+      io.deq.bits :<= (if parameter.flow then queue.io.empty ? (io.enq.bits, storedData) else storedData)
 
-    io.empty := queue.io.empty
-    io.full  := queue.io.full
-    io.almostEmpty.foreach(_ := queue.io.almostEmpty)
-    io.almostFull.foreach(_ := queue.io.almostFull)
+      io.empty := queue.io.empty
+      io.full  := queue.io.full
+      io.almostEmpty.foreach(_ := queue.io.almostEmpty)
+      io.almostFull.foreach(_ := queue.io.almostFull)
 
     io
 


### PR DESCRIPTION
## Summary

This PR adopts the RegMap design from `mmio-regmap-api` (Jiuyang Liu's commits up to `f047387`) and adds five commits: three fix transaction semantics, one adds coverage, one adds tests. The API shape is unchanged.

The Parameter defines the layout and each field capability. No hardware exists at this point.

```scala
val enable   = RegField("enable", 8).readValue.writeValue
val busy     = RegField("busy", 1).readValue
val command  = RegField("command", 8).writeReadyValid
val snapshot = RegField("snapshot", 1).readRequestResponse.writeValue
val verification = Layer("Verification")
val regMap   = RegMapDefinition(indexWidth = 6, dataWidth = 32, assertionLayer = verification, queueEntries = 1, reportError = true)(
  0x00 -> Seq(enable),
  0x04 -> Seq(busy, busyReserved),
  0x08 -> Seq(command),
  0x0c -> Seq(snapshot)
)
```

The architecture binds signals to each capability. `RegMapDefinition.apply` builds the decoder and the handshakes.

```scala
parameter.regMap(io.req, io.rsp)(
  parameter.enable.read(enable),
  parameter.enable.write(enable),
  parameter.busy.read(io.busy.asBits),
  parameter.command.write(io.commandReady, io.commandValid, io.commandData),
  parameter.snapshot.read(snapshotRequestReady, snapshotRequestValid, snapshotResponseReady, snapshotResponseValid, snapshotData),
  parameter.snapshot.write(snapshotWritable)
)
```

| Capability | When it acts |
|---|---|
| `readValue`, `writeValue` | when the RegMap accepts the request (`req.fire`) |
| `readReadyValid`, `writeReadyValid` | one transfer at `req.fire` |
| `readRequestResponse`, `writeRequestResponse` | request at `req.fire`, response consumed at `rsp.fire` |

## Issues found in `f047387`

Ordered by severity.

| # | Issue | Real? | Fix |
|---|---|---|---|
| 1 | With `queueEntries >= 2`, a later request-response request could start before an earlier write committed | Yes, simulation | `63fd14f` |
| 2 | `rsp.bits.data` changed while `rsp.valid && !rsp.ready` | Yes, BMC | `63fd14f` |
| 3 | `writeReadyValid` dropped `valid` when `rsp.ready` dropped | Yes, BMC | `63fd14f` |
| 4 | Assertions checked only the `req` side | Gap, not a bug | `62562a4` |
| 5 | Two fields could carry one name (`a.writeValue` keeps the name of `a`), and the error named the wrong field | Yes, diagnostics only | `4d9f89a` |
| 6 | No coverage | Gap | `14291df` |
| 7 | No test exercised the RegMap | Gap | `5735514` |

### 1 to 3: one cause, one fix

Before: `readValue`, `writeValue` and ready-valid fields acted when the response left the RegMap. Request-response fields started when the request entered. With two queue entries the order between the two groups broke.

Example with `queueEntries = 2` and `rsp.ready` low:

| Cycle | Bus | Before | After |
|---|---|---|---|
| 4 | write `ctrl = 0x5a` accepted | write waits in the queue | `ctrl` becomes `0x5a` |
| 6 | read `mirror` accepted, its request fires | `mirror` samples `ctrl = 0x00` | `mirror` samples `0x5a` |
| 10 | write response leaves | `ctrl` becomes `0x5a` | no change |
| 11 | read response leaves | data `0x00` | data `0x5a` |

Now every field acts at `req.fire`. Read data is sampled at that moment and travels with the queue entry, so the response cannot change while stalled (#2). The ready-valid handshakes no longer see `rsp.ready` (#3).

`queueEntries = 0` remains a combinational bridge. It has no storage, so a stalled response follows the bound value and a ready-valid write still depends on `rsp.ready`. Use `queueEntries >= 1` for a Decoupled-conformant response.

### 4: response assertions

The assertion layer now also checks that `rsp.valid` stays high and `rsp.bits.*` stays stable while the response is stalled. This is the contract the layer already required from the requester.

### 5: duplicate field names

`RegMapDefinition` requires every field name to be distinct, checked when the parameter is built. Field names become cover labels, so a duplicate would also produce a duplicate label.

### 6: coverage

Cover points, all inside `assertionLayer` next to the existing assertions. The layer parameter is unchanged from `f047387`.

Cover points:

| Label | Event |
|---|---|
| `regmap_read_accept`, `regmap_write_accept` | a request is accepted |
| `regmap_request_stall`, `regmap_response_stall` | a side is stalled |
| `regmap_accept_with_response_pending` | a request is accepted while a response waits (`queueEntries >= 1`) |
| `regmap_error_response` | an unmapped index is answered (`reportError`) |
| `regmap_<field>_read`, `regmap_<field>_write` | the field acts |
| `regmap_<field>_read_response`, `regmap_<field>_write_response` | a request-response field completes |
| `regmap_<field>_write_masked_out` | a write hits the word but not every byte lane of the field |

### 7: tests

`stdlib/lit/tests/RegMapSpec.scala` checks two small designs with `circt-bmc` (bound 10, `queueEntries = 1`). The RegMap's own assertion layer is disabled during the check; the contracts are an independent oracle. Every property compares one cycle with the previous one, so no reset assumption is needed.

Every property below fails on `f047387`. A property that passes both before and after the fix would not test this series, so there is none.

| Design | Property |
|---|---|
| read | response stable while stalled |
| read | `readValue` returns the value sampled when the request was accepted |
| read | `readReadyValid` transfers exactly when its request is accepted |
| read | `readReadyValid` returns the transferred data |
| write | `writeReadyValid` holds valid and data while stalled |
| write | `writeReadyValid` transfers exactly when its request is accepted |
| write | accepted write is answered the next cycle |
| write | `writeValue` commits when its request is accepted |
| write | `writeValue` field changes only when a write is accepted |

The same file checks the emitted Verilog: `assert` and `cover` only in `RegMapRead_Verification`, neither in `RegMapRead`.

The `queueEntries = 2` ordering hazard (#1) is not in the suite: `circt-bmc` rejects the two-entry queue's active-low reset. Its cause, `writeValue` committing late, is the `writeValue commits when its request is accepted` property above, which does not depend on queue depth.

## Verified

| Check | `f047387` | this PR |
|---|---|---|
| `RegMapSpec.scala`, 9 BMC properties | all violated | no violation |
| Simulation, `queueEntries = 2`: write `ctrl`, then request-response read of `ctrl` | reads `0x00` | reads `0x5a` |
| `mill __.checkFormat`, `mill __.testForked`, `mill stdlib.lit.tests.run` | | pass |

The `queueEntries = 2` simulation is a one-off; its testbench is available on request.

## Not changed, by design

| Behavior | Why |
|---|---|
| A write whose mask covers only part of a field is dropped without an error | Same as Rocket `RegMapper`. A field writes only when every byte lane it covers is enabled |
| With `queueEntries >= 2`, a later request can be accepted before an earlier request-response field completes | The field owns its completion. `queueEntries = 1` serializes fully |
| Multibeat and misaligned access | Belong to an outer MMIO adapter |
| Two request-response fields in one word whose `requestReady` depends on `requestValid` form a loop | Inherent to the join, same as Rocket |
