### PR TITLE
[zaozi] add SVA past API

### DIFF
--- a/circtlib/src/dialect/firrtl/ExpressionAPI.scala
+++ b/circtlib/src/dialect/firrtl/ExpressionAPI.scala
@@ -3,7 +3,7 @@
 package org.llvm.circt.scalalib.dialect.firrtl.operation
 
 import org.llvm.mlir.scalalib.capi.support.HasOperation
-import org.llvm.mlir.scalalib.capi.ir.{Context, Location, Operation, Value}
+import org.llvm.mlir.scalalib.capi.ir.{Context, Location, Operation, Type, Value}
 import org.llvm.circt.scalalib.capi.dialect.firrtl.FirrtlEventControl
 
 import java.lang.foreign.Arena
@@ -321,7 +321,20 @@ trait VectorCreateApi extends HasOperation[VectorCreate]
 end VectorCreateApi
 
 class VerbatimExpr(val _operation: Operation)
-trait VerbatimExprApi extends HasOperation[VerbatimExpr]
+trait VerbatimExprApi extends HasOperation[VerbatimExpr]:
+  def op(
+    text:          String,
+    substitutions: Seq[Value],
+    resultType:    Type,
+    location:      Location
+  )(
+    using Arena,
+    Context
+  ):   VerbatimExpr
+  extension (ref: VerbatimExpr)
+    def result(
+      using Arena
+    ): Value
 end VerbatimExprApi
 
 class VerbatimWire(val _operation: Operation)

--- a/circtlib/src/dialect/firrtl/Implementation.scala
+++ b/circtlib/src/dialect/firrtl/Implementation.scala
@@ -897,6 +897,35 @@ given VerifEnsureApi with
 end given
 // Expression
 
+given VerbatimExprApi with
+  def op(
+    text:          String,
+    substitutions: Seq[Value],
+    resultType:    Type,
+    location:      Location
+  )(
+    using Arena,
+    Context
+  ): VerbatimExpr =
+    VerbatimExpr(
+      summon[OperationApi].operationCreate(
+        name = "firrtl.verbatim.expr",
+        location = location,
+        operands = substitutions,
+        resultsTypes = Some(Seq(resultType)),
+        namedAttributes = Seq(
+          summon[NamedAttributeApi].namedAttributeGet("text".identifierGet, text.stringAttrGet),
+          summon[NamedAttributeApi].namedAttributeGet("symbols".identifierGet, Seq.empty.arrayAttrGet)
+        )
+      )
+    )
+  extension (ref: VerbatimExpr)
+    def operation: Operation = ref._operation
+    def result(
+      using Arena
+    ): Value = ref.operation.getResult(0)
+end given
+
 given LTLAndIntrinsicApi with
   def op(
     inputs:   Seq[Value],

--- a/doc/bugs/circt-forceable-ref-cast-comb-loops.md
+++ b/doc/bugs/circt-forceable-ref-cast-comb-loops.md
@@ -1,0 +1,109 @@
+# FIRRTL combinational-loop analysis crashes on a cast forceable register reference
+
+## Status
+
+- Recorded: 2026-09-08.
+- Reproduced with CIRCT `306d4f5c0f1b03575a17665d8f2592c33feb8be0`,
+  pinned by this repository's `flake.lock` (firtool 1.154.0).
+- Reproduced on Linux x86-64 with assertions enabled in the affected code.
+- No upstream issue or fix has been submitted as part of this change.
+- Blocks `ZAOZI :: ProbeForce.scala` during Verilog generation.
+
+## Reproduction
+
+Run from the repository root, using the pinned development environment:
+
+```sh
+nix develop --no-update-lock-file
+circt-opt doc/bugs/circt-forceable-ref-cast-comb-loops.mlir -o /dev/null
+circt-opt --firrtl-check-comb-loops doc/bugs/circt-forceable-ref-cast-comb-loops.mlir -o /dev/null
+```
+
+The first command after entering the shell succeeds: the standalone
+[MLIR file](circt-forceable-ref-cast-comb-loops.mlir) passes parsing and
+verification. The second aborts (observed process exit code 134).
+
+The reproducer contains a register, an output driven by that register, and a
+writable probe. The reference is routed as follows:
+
+```text
+forceable register's SSA reference
+  -> ref.cast adding layer @Test
+  -> ref.define to an output probe
+```
+
+No force/release statement is needed to trigger the crash. There is no
+combinational feedback in this design.
+
+## Expected and Actual Results
+
+Expected: combinational-loop analysis succeeds without reporting a cycle.
+
+Actual:
+
+```text
+llvm/ADT/EquivalenceClasses.h:192:
+Assertion `MI != member_end() && "Value is not in the set!"' failed.
+```
+
+Relevant frames:
+
+```text
+DiscoverLoops::addToPortPathsIfRWProbe
+DiscoverLoops::dfsTraverse
+CheckCombLoopsPass::runOnOperation
+```
+
+This is a failed internal bookkeeping assumption, not a detected-cycle
+diagnostic. As a control, an uncolored probe defined directly from the same
+register reference, without the cast/layer block, passed the analysis.
+
+## Source Analysis
+
+The following analysis is based on the pinned revision, not a claim about
+current upstream HEAD:
+
+1. In [CheckCombLoops.cpp](https://github.com/llvm/circt/blob/306d4f5c0f1b03575a17665d8f2592c33feb8be0/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp),
+   `constructConnectivityGraph` matches `hw::CombDataFlow` before
+   `Forceable` in a `TypeSwitch`.
+2. `RegOp` implements both interfaces. Its
+   [computeDataFlow implementation](https://github.com/llvm/circt/blob/306d4f5c0f1b03575a17665d8f2592c33feb8be0/lib/Dialect/FIRRTL/FIRRTLOps.cpp)
+   returns no combinational edges. The `Forceable` branch, which would call
+   `recordProbe(data, ref)`, is therefore skipped for the register.
+3. `RefDefineOp` unions its source and destination in `rwProbeClasses`.
+   With the cast present, these are the cast result and the output probe,
+   not the register's original reference.
+4. `RefCastOp` has no dedicated handling that unions its input and output
+   as aliases of the same writable target. Generic dataflow handling does
+   not establish this equivalence.
+5. `addToPortPathsIfRWProbe` later calls
+   `rwProbeClasses.getLeaderValue(getOrAddNode(defOp.getDataRef()))`.
+   The original register reference was never inserted into that equivalence
+   set, so the lookup asserts.
+
+The direct, uncolored control avoids the assertion because `ref.define`
+itself inserts the original register reference into the set. Passing that
+control does not prove that all forceable-register dataflow is modeled correctly.
+
+## Suggested Upstream Fix
+
+These are proposed changes, not an implemented or verified fix:
+
+- Register forceable-target metadata independently of the mutually exclusive
+  combinational-dataflow dispatch, while retaining the register's sequential
+  boundary.
+- Track alias equivalence across casts between writable reference types.
+- Add regressions for forceable registers and reset registers, layer-colored
+  casts, shared references, and cross-module force paths. Include real
+  combinational-loop cases to verify that detection remains effective.
+
+Simply ignoring a missing equivalence-set entry or disabling the pass would
+hide incomplete analysis and is not a sufficient fix.
+
+## Zaozi Impact
+
+The SSA implementation and its 13 focused unit tests pass, but the complete
+Zaozi lit run is 9/10: `ProbeForce.scala` passes its MLIR checks and crashes
+in firtool at this pass. The test remains enabled and is not marked XFAIL.
+No fallback to symbol-based references or check-disabling workaround has
+been added.

--- a/doc/bugs/circt-forceable-ref-cast-comb-loops.mlir
+++ b/doc/bugs/circt-forceable-ref-cast-comb-loops.mlir
@@ -1,0 +1,14 @@
+module {
+  firrtl.circuit "Repro" {
+    firrtl.layer @Test bind {}
+    firrtl.module @Repro(in %clock: !firrtl.clock, in %data: !firrtl.uint<8>, out %out: !firrtl.uint<8>, out %probe: !firrtl.rwprobe<uint<8>, @Test>) {
+      %target, %target_ref = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+      firrtl.connect %target, %data : !firrtl.uint<8>
+      firrtl.connect %out, %target : !firrtl.uint<8>
+      firrtl.layerblock @Test {
+        %ref = firrtl.ref.cast %target_ref : (!firrtl.rwprobe<uint<8>>) -> !firrtl.rwprobe<uint<8>, @Test>
+        firrtl.ref.define %probe, %ref : !firrtl.rwprobe<uint<8>, @Test>
+      }
+    }
+  }
+}

--- a/doc/pr-probe-force-release.md
+++ b/doc/pr-probe-force-release.md
@@ -1,0 +1,57 @@
+# Add force/release support for writable probes using SSA references
+
+## Summary
+
+- Add `force`, `release`, `forceInitial`, and `releaseInitial` to `RWProbe`.
+- Add an opt-in `forceable = true` argument to `Wire`, `Reg`, `RegInit`, and
+  `Node`; existing declarations remain non-forceable by default.
+- Bind writable probes to the declaration's second SSA result instead of
+  constructing `firrtl.ref.rwprobe` operations or allocating internal symbols.
+- Keep `ref.send` for read-only probes and reject writable bindings to literals
+  or declarations that were not created as forceable.
+- Correct the operation name emitted by `RefReleaseInitialApi` to
+  `firrtl.ref.release_initial`.
+
+## Usage
+
+Inside a generator with a writable probe field and the corresponding layer:
+
+```scala
+val target = Wire(UInt(8), forceable = true)
+target := io.data
+layer("Test"):
+  probe.x <== target
+  probe.x.force(io.data, io.clock, io.forceEnable)
+  probe.x.release(io.clock, io.releaseEnable)
+```
+
+The clocked methods take an explicit clock and enable and execute on rising
+edges. The initialization variants take `(value, enable)` and `(enable)`,
+respectively. These methods are not available on read-only probes.
+
+Writable binding currently supports whole Wire/Reg/Node declarations
+(including RegInit), not ports or aggregate subfields. Ordinary signal users
+continue to use the declaration's first SSA result.
+
+## Validation
+
+- ProbeForceSpec: 4/4 passed, including SSA reference reuse, type restrictions,
+  rejection of non-forceable targets, and reset-register support.
+- ReferableSpec: 8/8 passed.
+- LayerSpec: 1/1 passed.
+- Zaozi lit suite: 9/10 passed. The new ProbeForce.scala case passes MLIR
+  checks but fails during firtool's combinational-loop analysis.
+- `git diff --check` passed.
+
+## Known Blocker
+
+The pinned CIRCT revision
+`306d4f5c0f1b03575a17665d8f2592c33feb8be0` crashes in
+`firrtl-check-comb-loops` for a forceable register reference routed through
+a layer-colored `ref.cast`. This is an internal equivalence-set assertion,
+not a diagnostic reporting an actual combinational loop.
+
+See the [bug record](bugs/circt-forceable-ref-cast-comb-loops.md) and its
+[standalone reproducer](bugs/circt-forceable-ref-cast-comb-loops.mlir).
+The failing regression remains enabled; no compiler checks are disabled.
+End-to-end Verilog validation is still blocked on resolving this CIRCT issue.

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -1217,6 +1217,21 @@ trait SVAApi:
   def posedge(clock: Referable[Clock]): ClockEvent
   def negedge(clock: Referable[Clock]): ClockEvent
 
+  def past[D <: Bool | UInt | SInt | Bits](
+    value: Referable[D],
+    delay: Int = 1
+  )(
+    using ClockEvent
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Node[D]
+
   /** SVA: always p
     */
   def always(

--- a/zaozi/src/default/SVAApi.scala
+++ b/zaozi/src/default/SVAApi.scala
@@ -7,7 +7,7 @@ import me.jiuyang.zaozi.ltltpe.*
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 
-import org.llvm.circt.scalalib.capi.dialect.firrtl.FirrtlEventControl
+import org.llvm.circt.scalalib.capi.dialect.firrtl.{FirrtlEventControl, FirrtlNameKind}
 import org.llvm.circt.scalalib.dialect.firrtl.operation.{
   given_LTLAndIntrinsicApi,
   given_LTLClockedAtomIntrinsicApi,
@@ -22,6 +22,8 @@ import org.llvm.circt.scalalib.dialect.firrtl.operation.{
   given_LTLIntersectIntrinsicApi,
   given_LTLNotIntrinsicApi,
   given_LTLOrIntrinsicApi,
+  given_NodeApi,
+  given_VerbatimExprApi,
   given_VerifAssertApi,
   given_VerifAssumeApi,
   given_VerifCoverApi,
@@ -38,6 +40,8 @@ import org.llvm.circt.scalalib.dialect.firrtl.operation.{
   LTLIntersectIntrinsicApi as IntersectApi,
   LTLNotIntrinsicApi as NotApi,
   LTLOrIntrinsicApi as OrApi,
+  NodeApi,
+  VerbatimExprApi,
   VerifAssertApi as AssertApi,
   VerifAssumeApi as AssumeApi,
   VerifCoverApi as CoverApi
@@ -60,13 +64,46 @@ import org.llvm.mlir.scalalib.capi.ir.{
 
 import java.lang.foreign.Arena
 
-export given_SVAApi.{always, eventually, negedge, posedge, Assert, Assume, Cover}
+export given_SVAApi.{always, eventually, negedge, past, posedge, Assert, Assume, Cover}
 
 given SVAApi with
   def posedge(clock: Referable[Clock]): ClockEvent =
     ClockEvent(FirrtlEventControl.AtPosEdge, clock)
   def negedge(clock: Referable[Clock]): ClockEvent =
     ClockEvent(FirrtlEventControl.AtNegEdge, clock)
+
+  def past[D <: Bool | UInt | SInt | Bits](
+    value:       Referable[D],
+    delay:       Int = 1
+  )(
+    using clock: ClockEvent
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Node[D] =
+    require(delay > 0, s"past delay ($delay) must be greater than 0")
+    val input  = value.refer
+    val edge   = clock.edge match
+      case FirrtlEventControl.AtPosEdge => "posedge"
+      case FirrtlEventControl.AtNegEdge => "negedge"
+    // Keep the sampling clock in the call even when emission introduces a shared wire.
+    val pastOp = summon[VerbatimExprApi].op(
+      text = s"$$past({{0}}, $delay, , @($edge {{1}}))",
+      substitutions = Seq(input, clock.clock.refer),
+      resultType = input.getType,
+      location = locate
+    )
+    pastOp.operation.appendToBlock()
+    val nodeOp = summon[NodeApi].op(valName, locate, FirrtlNameKind.Interesting, pastOp.result)
+    nodeOp.operation.appendToBlock()
+    new Node[D]:
+      val _tpe:   D     = value.getType
+      val _refer: Value = nodeOp.operation.getResult(0)
 
   def always(
     property:    Immediate | Sequence | Property

--- a/zaozi/tests/src/PastSpec.scala
+++ b/zaozi/tests/src/PastSpec.scala
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+package me.jiuyang.zaozitest
+
+import java.lang.foreign.Arena
+import me.jiuyang.testlib.*
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.ltltpe.ClockEvent
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+import utest.*
+
+case class PastParameter(width: Int, falling: Boolean) extends Parameter
+given upickle.default.ReadWriter[PastParameter] = upickle.default.macroRW
+
+class PastLayers(parameter: PastParameter) extends LayerInterface(parameter):
+  def layers = Seq.empty
+
+class PastIO(parameter: PastParameter) extends HWBundle(parameter):
+  val clock   = Flipped(Clock())
+  val bool    = Flipped(Bool())
+  val uint    = Flipped(UInt(parameter.width))
+  val sint    = Flipped(SInt(parameter.width))
+  val bits    = Flipped(Bits(parameter.width))
+  val boolOut = Aligned(Bool())
+  val uintOut = Aligned(UInt(parameter.width))
+  val sintOut = Aligned(SInt(parameter.width))
+  val bitsOut = Aligned(Bits(parameter.width))
+
+class PastProbe(parameter: PastParameter) extends DVBundle[PastParameter, PastLayers](parameter)
+
+object PastSpec extends TestSuite:
+  val tests = Tests:
+    test("past preserves scalar types and widths on both clock edges"):
+      @generator
+      object G extends Generator[PastParameter, PastLayers, PastIO, PastProbe] with HasVerilogTest:
+        def architecture(parameter: PastParameter) =
+          val io           = summon[Interface[PastIO]]
+          given ClockEvent = if parameter.falling then negedge(io.clock) else posedge(io.clock)
+          val uintInput:    Referable[UInt] = io.uint
+          val previousBool: Node[Bool]      = past(io.bool)
+          val previousUInt: Node[UInt]      = past(uintInput, 2)
+          val previousSInt: Node[SInt]      = past(io.sint, 3)
+          val previousBits: Node[Bits]      = past(io.bits, 4)
+          assert(previousBool.width == 1)
+          assert(previousUInt.width == parameter.width)
+          assert(previousSInt.width == parameter.width)
+          assert(previousBits.width == parameter.width)
+          io.boolOut := previousBool
+          io.uintOut := previousUInt
+          io.sintOut := previousSInt
+          io.bitsOut := previousBits
+          compileError("past(io.clock)")
+          compileError("val wrong: Node[Bool] = past(io.uint)")
+          compileError("val wrong: Node[UInt] = past(io.sint)")
+
+      for
+        width   <- Seq(1, 13, 32)
+        falling <- Seq(false, true)
+      do
+        val edge    = if falling then "negedge" else "posedge"
+        val verilog = G.verilogString(PastParameter(width, falling))
+        assert(verilog.contains(s"$$past(bool, 1, , @($edge clock))"))
+        assert(verilog.contains(s"$$past(uint, 2, , @($edge clock))"))
+        assert(verilog.contains(s"$$past(sint, 3, , @($edge clock))"))
+        assert(verilog.contains(s"$$past(bits, 4, , @($edge clock))"))
+
+    test("past rejects non-positive delays for word values"):
+      @generator
+      object G extends Generator[PastParameter, PastLayers, PastIO, PastProbe] with HasCompileErrorTest:
+        def architecture(parameter: PastParameter) =
+          val io           = summon[Interface[PastIO]]
+          given ClockEvent = posedge(io.clock)
+          val zero         = intercept[IllegalArgumentException](past(io.uint, 0))
+          val negative     = intercept[IllegalArgumentException](past(io.sint, -1))
+          assert(zero.getMessage.contains("past delay (0)"))
+          assert(negative.getMessage.contains("past delay (-1)"))
+      G.compileErrorTest(PastParameter(13, false))

--- a/zaozi/tests/src/SVASpec.scala
+++ b/zaozi/tests/src/SVASpec.scala
@@ -870,6 +870,42 @@ object SVASpec extends TestSuite:
           "@(posedge clock) ib0 until ib0 and ib1"
         )
 
+      test("past"):
+        @generator
+        object SimpleSVA
+            extends Generator[SVASpecParameter, SVASpecLayers, SVASpecIO, SVASpecProbe]
+            with HasVerilogTest:
+          def architecture(parameter: SVASpecParameter) =
+            val io           = summon[Interface[SVASpecIO]]
+            given ClockEvent = posedge(io.clock)
+            val previous     = past(io.ib0, 2)
+
+            Assert(previous.S iff io.ib1.S, "past")
+
+        println(SimpleSVA.verilogString(SVASpecParameter(32)))
+        SimpleSVA.verilogTest(SVASpecParameter(32))(
+          "$past(ib0, 2, , @(posedge clock));"
+        )
+
+      test("past rejects non-positive delays"):
+        @generator
+        object InvalidPast
+            extends Generator[SVASpecParameter, SVASpecLayers, SVASpecIO, SVASpecProbe]
+            with HasCompileErrorTest:
+          def architecture(parameter: SVASpecParameter) =
+            val io           = summon[Interface[SVASpecIO]]
+            given ClockEvent = posedge(io.clock)
+
+            val zeroDelay = intercept[IllegalArgumentException]:
+              past(io.ib0, 0)
+            assert(zeroDelay.getMessage.contains("past delay (0)"))
+
+            val negativeDelay = intercept[IllegalArgumentException]:
+              past(io.ib0, -1)
+            assert(negativeDelay.getMessage.contains("past delay (-1)"))
+
+        InvalidPast.compileErrorTest(SVASpecParameter(32))
+
     test("Clock"):
       test("Simple"):
         @generator


### PR DESCRIPTION
## Summary

Add `past(value, delay)` to the SVA API.

`past` is expanded in the zaozi frontend into `$past`, using the `firrtl.verbatim.expr`

## Changes

- Add `past[T <: Referable[Bool]](value, delay = 1): Node[Bool]`.
- Add MLIR and Verilog tests for a two-cycle delay.

## Validation

- `nix develop -c mill zaozi.tests.testOnly me.jiuyang.zaozitest.SVASpec`
- `nix develop -c mill circtlib.compile zaozi.compile testlib.compile stdlib.compile __.checkFormat`
