### PR TITLE
[stdlib] refactor adder interfaces and implementations

### DIFF
--- a/stdlib/lit/tests/BrentKungAdder.sc
+++ b/stdlib/lit/tests/BrentKungAdder.sc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 
-// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.BrentKungAdder" %s --
+// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.adder.default.BrentKungAdder" %s --
 // DEFINE: %{bmc} = circt-bmc %t.dir/w8.contract.hw.mlir --module=BrentKungAdder_width8_radix2_CheckContract_0 -b 1 --shared-libs=%Z3LIB --run
 
 // width 8, radix 2
@@ -40,10 +40,10 @@
 // CONTRACT8: firrtl.int.verif.ensure
 
 // VERILOG8-LABEL: module BrentKungAdder_width8_radix2
-// VERILOG8: input{{ +}}[7:0]{{ +}}A,
-// VERILOG8: input{{ +}}CI,
-// VERILOG8: output{{ +}}CO,
-// VERILOG8: output{{ +}}[7:0]{{ +}}SUM
+// VERILOG8: input{{ +}}[7:0]{{ +}}a,
+// VERILOG8: input{{ +}}ci,
+// VERILOG8: output{{ +}}co,
+// VERILOG8: output{{ +}}[7:0]{{ +}}sum
 
 // LOWERED8-LABEL: hw.module @BrentKungAdder_width8_radix2
 // LOWERED8: verif.assume
@@ -57,17 +57,18 @@
 // CONFIG32R8: {"width":32,"radix":8}
 
 // VERILOG32R8-LABEL: module BrentKungAdder_width32_radix8
-// VERILOG32R8: input{{ +}}[31:0]{{ +}}A,
-// VERILOG32R8: input{{ +}}CI,
-// VERILOG32R8: output{{ +}}CO,
-// VERILOG32R8: output{{ +}}[31:0]{{ +}}SUM
+// VERILOG32R8: input{{ +}}[31:0]{{ +}}a,
+// VERILOG32R8: input{{ +}}ci,
+// VERILOG32R8: output{{ +}}co,
+// VERILOG32R8: output{{ +}}[31:0]{{ +}}sum
 // The radix-8 group-propagate fold emits wide AND-chains.
 // VERILOG32R8: {{.+ & .+ & .+ & .+ & .+ & .+ & .+ & .+}}
 
-// CONFIG32R4: {"width":32,"radix":4}
+// The default radix is omitted from the serialized configuration.
+// CONFIG32R4: {"width":32}
 
 // VERILOG32R4-LABEL: module BrentKungAdder_width32_radix4
-// VERILOG32R4: input{{ +}}[31:0]{{ +}}A,
-// VERILOG32R4: input{{ +}}CI,
-// VERILOG32R4: output{{ +}}CO,
-// VERILOG32R4: output{{ +}}[31:0]{{ +}}SUM
+// VERILOG32R4: input{{ +}}[31:0]{{ +}}a,
+// VERILOG32R4: input{{ +}}ci,
+// VERILOG32R4: output{{ +}}co,
+// VERILOG32R4: output{{ +}}[31:0]{{ +}}sum

--- a/stdlib/lit/tests/Incrementer.sc
+++ b/stdlib/lit/tests/Incrementer.sc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 
-// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.Incrementer" %s --
+// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.adder.default.Incrementer" %s --
 // DEFINE: %{bmc} = circt-bmc %t.dir/w8.contract.hw.mlir --module=Incrementer_width8_radix4_CheckContract_0 -b 1 --shared-libs=%Z3LIB --run
 
 // width 8
@@ -22,8 +22,8 @@
 // CONTRACT8: firrtl.int.verif.ensure
 
 // VERILOG8-LABEL: module Incrementer_width8_radix4
-// VERILOG8: input{{ +}}[7:0]{{ +}}A,
-// VERILOG8: output{{ +}}[7:0]{{ +}}SUM
+// VERILOG8: input{{ +}}[7:0]{{ +}}a,
+// VERILOG8: output{{ +}}[7:0]{{ +}}sum
 
 // LOWERED8-LABEL: hw.module @Incrementer_width8_radix4
 // LOWERED8: verif.assume

--- a/stdlib/lit/tests/RippleAdder.sc
+++ b/stdlib/lit/tests/RippleAdder.sc
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+
+// DEFINE: %{test} = scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION -O="-experimental" %JAVAOPTS --main-class "me.jiuyang.stdlib.adder.default.RippleAdder" %s --
+// DEFINE: %{bmc} = circt-bmc -b 1 --shared-libs=%Z3LIB --run
+
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+// RUN: %{test} config %t.dir/w1.json --width 1
+// RUN: cd %t.dir && %{test} design %t.dir/w1.json
+// RUN: firtool %t.dir/RippleAdder_width1.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/w1.hw.mlir --disable-output
+// RUN: %{bmc} %t.dir/w1.hw.mlir --module=RippleAdder_width1_CheckContract_0 | FileCheck %s --check-prefix=BMC
+
+// RUN: %{test} config %t.dir/w5.json --width 5
+// RUN: FileCheck %s --check-prefix=CONFIG --input-file=%t.dir/w5.json
+// RUN: cd %t.dir && %{test} design %t.dir/w5.json
+// RUN: circt-opt %t.dir/RippleAdder_width5.mlirbc | FileCheck %s --check-prefix=STRUCTURE
+// RUN: firtool %t.dir/RippleAdder_width5.mlirbc | FileCheck %s --check-prefix=VERILOG
+// RUN: firtool %t.dir/RippleAdder_width5.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/w5.hw.mlir --disable-output
+// RUN: %{bmc} %t.dir/w5.hw.mlir --module=RippleAdder_width5_CheckContract_0 | FileCheck %s --check-prefix=BMC
+
+// RUN: %{test} config %t.dir/w32.json --width 32
+// RUN: cd %t.dir && %{test} design %t.dir/w32.json
+// RUN: firtool %t.dir/RippleAdder_width32.mlirbc --hw-pass-plugin='lower-contracts' --output-hw-mlir=%t.dir/w32.hw.mlir --disable-output
+// RUN: %{bmc} %t.dir/w32.hw.mlir --module=RippleAdder_width32_CheckContract_0 | FileCheck %s --check-prefix=BMC
+// RUN: rm -rf %t.dir
+
+// CONFIG: {"width":5}
+
+// STRUCTURE-LABEL: firrtl.module @RippleAdder_width5
+// STRUCTURE-NOT: firrtl.add
+// STRUCTURE: firrtl.xor
+// STRUCTURE: firrtl.and
+// STRUCTURE: firrtl.or
+// STRUCTURE: firrtl.contract
+// STRUCTURE: firrtl.int.verif.ensure
+
+// VERILOG-LABEL: module RippleAdder_width5(
+// VERILOG: input{{ +}}[4:0]{{ +}}a,
+// VERILOG: input{{ +}}ci,
+// VERILOG: output{{ +}}co,
+// VERILOG: output{{ +}}[4:0]{{ +}}sum
+
+// BMC: Bound reached with no violations!

--- a/stdlib/src/AbsVal.scala
+++ b/stdlib/src/AbsVal.scala
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 package me.jiuyang.stdlib
 
+import me.jiuyang.stdlib.adder.PrefixAdderParameter
+import me.jiuyang.stdlib.adder.default.Incrementer
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*
@@ -34,10 +36,10 @@ object AbsVal extends Generator[AbsValParameter, AbsValLayers, AbsValIO, AbsValP
   def architecture(parameter: AbsValParameter) =
     val io   = summon[Interface[AbsValIO]]
     val sign = io.A.bit(parameter.width - 1)
-    val neg  = Incrementer.instantiate(BKAIncrementerParameter(parameter.width))
-    neg.io.A := ~io.A
+    val neg  = Incrementer.instantiate(PrefixAdderParameter(parameter.width))
+    neg.io.a := ~io.A
 
-    val absVal        = sign ? (neg.io.SUM, io.A)
+    val absVal        = sign ? (neg.io.sum, io.A)
     val checkedAbsVal = Contract(absVal) { value =>
       val negExpected = (0.U(parameter.width) - io.A.asUInt).asBits.bits(parameter.width - 1, 0)
       val expected    = sign ? (negExpected, io.A)

--- a/stdlib/src/AbsVal.scala
+++ b/stdlib/src/AbsVal.scala
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 package me.jiuyang.stdlib
 
-import me.jiuyang.stdlib.adder.PrefixAdderParameter
+import me.jiuyang.stdlib.adder.default.PrefixAdderParameter
 import me.jiuyang.stdlib.adder.default.Incrementer
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}

--- a/stdlib/src/adder/Adder.scala
+++ b/stdlib/src/adder/Adder.scala
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+package me.jiuyang.stdlib.adder
+
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
+
+import java.lang.foreign.Arena
+
+/** Backend-independent configuration for a fixed-width unsigned adder. */
+trait AdderParameter extends Parameter:
+  def width: Int
+
+case class PrefixAdderParameter(width: Int, radix: Int = 4) extends AdderParameter:
+  require(width > 0, "width must be positive")
+  require(radix >= 2, "radix must be at least 2")
+
+given upickle.default.ReadWriter[PrefixAdderParameter] = upickle.default.macroRW
+
+class AdderLayers[P <: AdderParameter](parameter: P) extends LayerInterface(parameter):
+  def layers = Seq.empty
+
+/** Backend-independent combinational adder interface. */
+class AdderIO[P <: AdderParameter](parameter: P) extends HWBundle(parameter):
+  val a   = Flipped(Bits(parameter.width))
+  val b   = Flipped(Bits(parameter.width))
+  val ci  = Flipped(Bool())
+  val co  = Aligned(Bool())
+  val sum = Aligned(Bits(parameter.width))
+
+class AdderProbe[P <: AdderParameter](parameter: P) extends DVBundle[P, AdderLayers[P]](parameter)
+
+object Adder:
+  def apply(
+    parameter: PrefixAdderParameter
+  )(
+    using Arena,
+    AdderImpl,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Wire[AdderIO[PrefixAdderParameter]] = summon[AdderImpl].apply(parameter)
+
+/** Implementation hook for the portable [[Adder]] interface. */
+trait AdderImpl:
+  def apply(
+    parameter: PrefixAdderParameter
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Wire[AdderIO[PrefixAdderParameter]]

--- a/stdlib/src/adder/Adder.scala
+++ b/stdlib/src/adder/Adder.scala
@@ -14,12 +14,6 @@ import java.lang.foreign.Arena
 trait AdderParameter extends Parameter:
   def width: Int
 
-case class PrefixAdderParameter(width: Int, radix: Int = 4) extends AdderParameter:
-  require(width > 0, "width must be positive")
-  require(radix >= 2, "radix must be at least 2")
-
-given upickle.default.ReadWriter[PrefixAdderParameter] = upickle.default.macroRW
-
 class AdderLayers[P <: AdderParameter](parameter: P) extends LayerInterface(parameter):
   def layers = Seq.empty
 
@@ -34,8 +28,8 @@ class AdderIO[P <: AdderParameter](parameter: P) extends HWBundle(parameter):
 class AdderProbe[P <: AdderParameter](parameter: P) extends DVBundle[P, AdderLayers[P]](parameter)
 
 object Adder:
-  def apply(
-    parameter: PrefixAdderParameter
+  def apply[P <: AdderParameter](
+    parameter: P
   )(
     using Arena,
     AdderImpl,
@@ -45,12 +39,12 @@ object Adder:
     sourcecode.Line,
     sourcecode.Name.Machine,
     InstanceContext
-  ): Wire[AdderIO[PrefixAdderParameter]] = summon[AdderImpl].apply(parameter)
+  ): Wire[AdderIO[P]] = summon[AdderImpl].apply(parameter)
 
 /** Implementation hook for the portable [[Adder]] interface. */
 trait AdderImpl:
-  def apply(
-    parameter: PrefixAdderParameter
+  def apply[P <: AdderParameter](
+    parameter: P
   )(
     using Arena,
     Context,
@@ -59,4 +53,4 @@ trait AdderImpl:
     sourcecode.Line,
     sourcecode.Name.Machine,
     InstanceContext
-  ): Wire[AdderIO[PrefixAdderParameter]]
+  ): Wire[AdderIO[P]]

--- a/stdlib/src/adder/default/BrentKungAdder.scala
+++ b/stdlib/src/adder/default/BrentKungAdder.scala
@@ -1,26 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 xinpian-tech
-package me.jiuyang.stdlib
+package me.jiuyang.stdlib.adder.default
 
+import java.lang.foreign.Arena
+
+import me.jiuyang.stdlib.adder.{AdderIO, AdderImpl, AdderLayers, AdderProbe, PrefixAdderParameter, given}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
 
 import scala.collection.immutable.SeqMap
-
-case class BrentKungAdderParameter(width: Int, radix: Int) extends Parameter with PrefixAdderParameter:
-  require(width > 0, "width must be positive")
-  require(radix >= 2, "radix must be at least 2")
-
-given upickle.default.ReadWriter[BrentKungAdderParameter] = upickle.default.macroRW
-
-class BrentKungAdderLayers(parameter: BrentKungAdderParameter) extends PrefixAdderLayers(parameter)
-
-class BrentKungAdderIO(parameter: BrentKungAdderParameter) extends PrefixAdderIO(parameter)
-
-class BrentKungAdderProbe(parameter: BrentKungAdderParameter)
-    extends DVBundle[BrentKungAdderParameter, BrentKungAdderLayers](parameter)
 
 private def buildBrentKungPrefixTree(width: Int, radix: Int): PrefixNode =
   // width here is including the carry-out column for the adder,
@@ -45,15 +36,15 @@ private def buildBrentKungPrefixTree(width: Int, radix: Int): PrefixNode =
 @generator
 object BrentKungAdder
     extends Generator[
-      BrentKungAdderParameter,
-      BrentKungAdderLayers,
-      BrentKungAdderIO,
-      BrentKungAdderProbe
+      PrefixAdderParameter,
+      AdderLayers[PrefixAdderParameter],
+      AdderIO[PrefixAdderParameter],
+      AdderProbe[PrefixAdderParameter]
     ]:
-  override def moduleName(p: BrentKungAdderParameter): String = s"BrentKungAdder_width${p.width}_radix${p.radix}"
+  override def moduleName(p: PrefixAdderParameter): String = s"BrentKungAdder_width${p.width}_radix${p.radix}"
 
-  def architecture(parameter: BrentKungAdderParameter) =
-    val io       = summon[Interface[BrentKungAdderIO]].asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
+  def architecture(parameter: PrefixAdderParameter) =
+    val io       = summon[Interface[AdderIO[PrefixAdderParameter]]]
     val treeRoot = buildBrentKungPrefixTree(parameter.width + 1, parameter.radix)
     val allNodes = flattenPrefixTree(treeRoot)
     val leaves   = prefixTreeLeaves(allNodes)
@@ -62,8 +53,8 @@ object BrentKungAdder
     // Bit i of A/B, zero-extended: real bit for i < width, else constant 0. The
     // extra column i == width is the carry-out column — a real leaf of the tree
     // with A=B=0, whose sum bit (0^0)^carry_width = carry_width IS the adder CO.
-    def aBit(i: Int): Referable[Bool] = if i < width then io.A.bit(i) else false.B
-    def bBit(i: Int): Referable[Bool] = if i < width then io.B.bit(i) else false.B
+    def aBit(i: Int): Referable[Bool] = if i < width then io.a.bit(i) else false.B
+    def bBit(i: Int): Referable[Bool] = if i < width then io.b.bit(i) else false.B
 
     // A node's group (G, P) is formed only where some ancestor's carry-threading
     // will consume it. The rightmost spine — root, then last-child down to the top
@@ -96,7 +87,7 @@ object BrentKungAdder
     // own — its children's carries are threaded straight from CI. That makes the
     // root just another internal node in the down-sweep: one unified recursion,
     // no carry-out cell. The carry into the CO column already IS the carry-out.
-    val leafCarries = threadPrefixCarries(treeRoot, io.CI) { (child, c) =>
+    val leafCarries = threadPrefixCarries(treeRoot, io.ci) { (child, c) =>
       (propagates(child) & c) | generates(child)
     }.toMap
 
@@ -110,9 +101,31 @@ object BrentKungAdder
 
     val (checkedCO, checkedSUM) = Contract((carryOut, sumWord)) { case (co, sum) =>
       val observed = (co.asBits ## sum).asUInt
-      val expected = (io.A.asUInt + io.B.asUInt + io.CI.asBits.asUInt).asBits.bits(width, 0).asUInt
+      val expected = (io.a.asUInt + io.b.asUInt + io.ci.asBits.asUInt).asBits.bits(width, 0).asUInt
       Ensure((observed === expected).I, "prefix_adder_matches_add")
     }
 
-    io.SUM := checkedSUM
-    io.CO  := checkedCO
+    io.sum := checkedSUM
+    io.co  := checkedCO
+
+given AdderImpl with
+  def apply(
+    parameter: PrefixAdderParameter
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Wire[AdderIO[PrefixAdderParameter]] =
+    val io      = Wire(new AdderIO(parameter))
+    val adderIO = BrentKungAdder.instantiate(parameter).io
+
+    adderIO.a  := io.a
+    adderIO.b  := io.b
+    adderIO.ci := io.ci
+    io.co      := adderIO.co
+    io.sum     := adderIO.sum
+    io

--- a/stdlib/src/adder/default/BrentKungAdder.scala
+++ b/stdlib/src/adder/default/BrentKungAdder.scala
@@ -2,14 +2,11 @@
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 package me.jiuyang.stdlib.adder.default
 
-import java.lang.foreign.Arena
-
-import me.jiuyang.stdlib.adder.{AdderIO, AdderImpl, AdderLayers, AdderProbe, PrefixAdderParameter, given}
+import me.jiuyang.stdlib.adder.{AdderIO, AdderLayers, AdderProbe}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
-import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
 
 import scala.collection.immutable.SeqMap
 
@@ -107,25 +104,3 @@ object BrentKungAdder
 
     io.sum := checkedSUM
     io.co  := checkedCO
-
-given AdderImpl with
-  def apply(
-    parameter: PrefixAdderParameter
-  )(
-    using Arena,
-    Context,
-    Block,
-    sourcecode.File,
-    sourcecode.Line,
-    sourcecode.Name.Machine,
-    InstanceContext
-  ): Wire[AdderIO[PrefixAdderParameter]] =
-    val io      = Wire(new AdderIO(parameter))
-    val adderIO = BrentKungAdder.instantiate(parameter).io
-
-    adderIO.a  := io.a
-    adderIO.b  := io.b
-    adderIO.ci := io.ci
-    io.co      := adderIO.co
-    io.sum     := adderIO.sum
-    io

--- a/stdlib/src/adder/default/Incrementer.scala
+++ b/stdlib/src/adder/default/Incrementer.scala
@@ -1,27 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 xinpian-tech
-package me.jiuyang.stdlib
+package me.jiuyang.stdlib.adder.default
 
+import me.jiuyang.stdlib.adder.{PrefixAdderParameter, given}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 
-// same parameters as BrentKungAdder
-case class BKAIncrementerParameter(width: Int, radix: Int = 4) extends Parameter with PrefixAdderParameter:
-  require(width > 0, "width must be positive")
-  require(radix >= 2, "radix must be at least 2")
+class IncrementerLayers(parameter: PrefixAdderParameter) extends LayerInterface(parameter):
+  def layers = Seq.empty
 
-given upickle.default.ReadWriter[BKAIncrementerParameter] = upickle.default.macroRW
+class IncrementerIO(parameter: PrefixAdderParameter) extends HWBundle(parameter):
+  val a   = Flipped(Bits(parameter.width))
+  val sum = Aligned(Bits(parameter.width))
 
-class IncrementerLayers(parameter: BKAIncrementerParameter) extends PrefixAdderLayers(parameter)
-
-class IncrementerIO(parameter: BKAIncrementerParameter) extends HWBundle(parameter):
-  val A   = Flipped(Bits(parameter.width))
-  val SUM = Aligned(Bits(parameter.width))
-
-class IncrementerProbe(parameter: BKAIncrementerParameter)
-    extends DVBundle[BKAIncrementerParameter, IncrementerLayers](parameter)
+class IncrementerProbe(parameter: PrefixAdderParameter)
+    extends DVBundle[PrefixAdderParameter, IncrementerLayers](parameter)
 
 /** Radix carry-look-ahead incrementer, `SUM = A + 1` mod 2^width.
   *
@@ -32,14 +27,14 @@ class IncrementerProbe(parameter: BKAIncrementerParameter)
 @generator
 object Incrementer
     extends Generator[
-      BKAIncrementerParameter,
+      PrefixAdderParameter,
       IncrementerLayers,
       IncrementerIO,
       IncrementerProbe
     ]:
-  override def moduleName(p: BKAIncrementerParameter): String = s"Incrementer_width${p.width}_radix${p.radix}"
+  override def moduleName(p: PrefixAdderParameter): String = s"Incrementer_width${p.width}_radix${p.radix}"
 
-  def architecture(parameter: BKAIncrementerParameter) =
+  def architecture(parameter: PrefixAdderParameter) =
     val io       = summon[Interface[IncrementerIO]]
     val treeRoot = buildBrentKungPrefixTree(parameter.width, parameter.radix)
     val allNodes = flattenPrefixTree(treeRoot)
@@ -47,7 +42,7 @@ object Incrementer
     val width    = leaves.map(_.idx).max + 1
 
     val internal   = prefixTreeInternalNodes(treeRoot, allNodes)
-    val propagates = prefixTreePropagates(leaves, internal)(n => io.A.bit(n.idx))
+    val propagates = prefixTreePropagates(leaves, internal)(n => io.a.bit(n.idx))
 
     val leafCarries = threadPrefixCarries(treeRoot, true.B) { (child, c) =>
       propagates(child) & c
@@ -57,8 +52,8 @@ object Incrementer
     val sumWord   = (1 until width).foldLeft(sumBitMap(0).asBits)((acc, i) => sumBitMap(i).asBits ## acc)
 
     val checkedSUM = Contract(sumWord) { sum =>
-      val expected = (io.A.asUInt + 1.U(width)).asBits.bits(width - 1, 0)
+      val expected = (io.a.asUInt + 1.U(width)).asBits.bits(width - 1, 0)
       Ensure((sum === expected).I, "incrementer_matches_add")
     }
 
-    io.SUM := checkedSUM
+    io.sum := checkedSUM

--- a/stdlib/src/adder/default/Incrementer.scala
+++ b/stdlib/src/adder/default/Incrementer.scala
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 package me.jiuyang.stdlib.adder.default
 
-import me.jiuyang.stdlib.adder.{PrefixAdderParameter, given}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*

--- a/stdlib/src/adder/default/PrefixAdderHelper.scala
+++ b/stdlib/src/adder/default/PrefixAdderHelper.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 xinpian-tech
-package me.jiuyang.stdlib
+package me.jiuyang.stdlib.adder.default
 
 import java.lang.foreign.Arena
 import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
@@ -95,16 +95,3 @@ def prefixTreeGenerates(
   internal.foldLeft(gMap0)((g, nd) =>
     g + (nd -> nd.leafs.tail.foldLeft[Referable[Bool]](g(nd.leafs.head))((acc, ch) => (propagates(ch) & acc) | g(ch)))
   )
-
-trait PrefixAdderParameter:
-  def width: Int
-
-class PrefixAdderLayers[P <: Parameter & PrefixAdderParameter](parameter: P) extends LayerInterface(parameter):
-  def layers = Seq.empty
-
-class PrefixAdderIO[P <: Parameter & PrefixAdderParameter](parameter: P) extends HWBundle[P](parameter):
-  val A   = Flipped(Bits(parameter.width))
-  val B   = Flipped(Bits(parameter.width))
-  val CI  = Flipped(Bool())
-  val CO  = Aligned(Bool())
-  val SUM = Aligned(Bits(parameter.width))

--- a/stdlib/src/adder/default/PrefixAdderHelper.scala
+++ b/stdlib/src/adder/default/PrefixAdderHelper.scala
@@ -3,6 +3,7 @@
 package me.jiuyang.stdlib.adder.default
 
 import java.lang.foreign.Arena
+import me.jiuyang.stdlib.adder.AdderParameter
 import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
@@ -10,6 +11,12 @@ import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 
 import scala.collection.immutable.SeqMap
+
+case class PrefixAdderParameter(width: Int, radix: Int = 4) extends AdderParameter:
+  require(width > 0, "width must be positive")
+  require(radix >= 2, "radix must be at least 2")
+
+given upickle.default.ReadWriter[PrefixAdderParameter] = upickle.default.macroRW
 
 // Generic radix prefix tree node. Leaves keep the original bit/column index;
 // internal node indices are only sibling-group indices produced by grouping.

--- a/stdlib/src/adder/default/RippleAdder.scala
+++ b/stdlib/src/adder/default/RippleAdder.scala
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+package me.jiuyang.stdlib.adder.default
+
+import java.lang.foreign.Arena
+
+import me.jiuyang.stdlib.adder.{AdderIO, AdderImpl, AdderLayers, AdderParameter, AdderProbe}
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
+
+case class RippleAdderParameter(width: Int) extends AdderParameter:
+  require(width > 0, "width must be positive")
+
+given upickle.default.ReadWriter[RippleAdderParameter] = upickle.default.macroRW
+
+/** Each full-adder consumes the carry from the preceding bit. */
+@generator
+object RippleAdder
+    extends Generator[
+      RippleAdderParameter,
+      AdderLayers[RippleAdderParameter],
+      AdderIO[RippleAdderParameter],
+      AdderProbe[RippleAdderParameter]
+    ]:
+  override def moduleName(p: RippleAdderParameter): String = s"RippleAdder_width${p.width}"
+
+  def architecture(parameter: RippleAdderParameter) =
+    val io = summon[Interface[AdderIO[RippleAdderParameter]]]
+    case class Stage(sum: Referable[Bool], carry: Referable[Bool])
+
+    val stages = (0 until parameter.width).scanLeft(Stage(false.B, io.ci)): (previous, index) =>
+      val a = io.a.bit(index)
+      val b = io.b.bit(index)
+      val c = previous.carry
+      Stage(a ^ b ^ c, (a & b) | (a & c) | (b & c))
+
+    val sums                    = stages.tail.map(_.sum)
+    val sumWord                 = sums.tail.foldLeft[Referable[Bits]](sums.head.asBits)((word, bit) => bit.asBits ## word)
+    val (checkedCO, checkedSUM) = Contract((stages.last.carry, sumWord)) { case (co, sum) =>
+      val observed = (co.asBits ## sum).asUInt
+      val expected = (io.a.asUInt + io.b.asUInt + io.ci.asBits.asUInt).asBits.bits(parameter.width, 0).asUInt
+      Ensure((observed === expected).I, "ripple_adder_matches_add")
+    }
+
+    io.sum := checkedSUM
+    io.co  := checkedCO
+
+given AdderImpl with
+  def apply[P <: AdderParameter](
+    parameter: P
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Wire[AdderIO[P]] =
+    val io      = Wire(new AdderIO(parameter))
+    val adderIO = RippleAdder.instantiate(RippleAdderParameter(parameter.width)).io
+
+    adderIO.a  := io.a
+    adderIO.b  := io.b
+    adderIO.ci := io.ci
+    io.co      := adderIO.co
+    io.sum     := adderIO.sum
+    io

--- a/stdlib/src/queue/default/AsyncQueue.scala
+++ b/stdlib/src/queue/default/AsyncQueue.scala
@@ -4,7 +4,8 @@ package me.jiuyang.stdlib.queue.default
 
 import java.lang.foreign.Arena
 
-import me.jiuyang.stdlib.{BKAIncrementerParameter, BrentKungAdder, BrentKungAdderParameter, Incrementer, PrefixAdderIO}
+import me.jiuyang.stdlib.adder.{Adder, PrefixAdderParameter}
+import me.jiuyang.stdlib.adder.default.{Incrementer, given}
 import me.jiuyang.stdlib.default.{Ram, RamParameter}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
@@ -215,9 +216,9 @@ private final class AsyncDirection(
         val advance    = request & !atBoundary
         val errorEvent = request & atBoundary
 
-        val pointerIncrementer = Incrementer.instantiate(BKAIncrementerParameter(pointerWidth))
-        pointerIncrementer.io.A := biasedPointer.asBits
-        val incrementedPointer = pointerIncrementer.io.SUM.asUInt
+        val pointerIncrementer = Incrementer.instantiate(PrefixAdderParameter(pointerWidth))
+        pointerIncrementer.io.a := biasedPointer.asBits
+        val incrementedPointer = pointerIncrementer.io.sum.asUInt
         val incremented        = advance ? (incrementedPointer, biasedPointer)
         val advancedPointer    =
           if geometry.needsCorrection then
@@ -235,13 +236,11 @@ private final class AsyncDirection(
         val (writePointer, readPointer) = kind match
           case AsyncDirectionKind.Push => (advancedPointer, remoteBinary)
           case AsyncDirectionKind.Pop  => (remoteBinary, advancedPointer)
-        val wordCountSubtractor         = BrentKungAdder.instantiate(BrentKungAdderParameter(pointerWidth, 4))
-        val wordCountSubtractIO         =
-          wordCountSubtractor.io.asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
-        wordCountSubtractIO.A  := writePointer.asBits
-        wordCountSubtractIO.B  := ~readPointer.asBits
-        wordCountSubtractIO.CI := true.B
-        val rawWordCount = wordCountSubtractIO.SUM.asUInt
+        val wordCountSubtractIO         = Adder(PrefixAdderParameter(pointerWidth, 4))
+        wordCountSubtractIO.a  := writePointer.asBits
+        wordCountSubtractIO.b  := ~readPointer.asBits
+        wordCountSubtractIO.ci := true.B
+        val rawWordCount = wordCountSubtractIO.sum.asUInt
         val wrapped      = writePointer < readPointer
 
         // Wrapped subtraction includes the reserved codes in a non-power-of-two ring. Remove those codes from the
@@ -253,22 +252,18 @@ private final class AsyncDirection(
             val rawHigh   = rawWordCount.asBits.bits(pointerWidth - 1, geometry.shift).asUInt
             val correctedHigh: Node[UInt] =
               if geometry.residual == 1 then
-                val decrementSubtractor = BrentKungAdder.instantiate(BrentKungAdderParameter(highWidth, 4))
-                val decrementSubtractIO =
-                  decrementSubtractor.io.asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
-                decrementSubtractIO.A  := rawHigh.asBits
-                decrementSubtractIO.B  := ~1.U(highWidth).asBits
-                decrementSubtractIO.CI := true.B
-                val decremented = decrementSubtractIO.SUM.asUInt
+                val decrementSubtractIO = Adder(PrefixAdderParameter(highWidth, 4))
+                decrementSubtractIO.a  := rawHigh.asBits
+                decrementSubtractIO.b  := ~1.U(highWidth).asBits
+                decrementSubtractIO.ci := true.B
+                val decremented = decrementSubtractIO.sum.asUInt
                 wrapped ? (decremented, rawHigh)
               else
-                val correctionSubtractor = BrentKungAdder.instantiate(BrentKungAdderParameter(highWidth, 4))
-                val correctionSubtractIO =
-                  correctionSubtractor.io.asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
-                correctionSubtractIO.A  := rawHigh.asBits
-                correctionSubtractIO.B  := ~geometry.residual.U(highWidth).asBits
-                correctionSubtractIO.CI := true.B
-                val subtracted   = correctionSubtractIO.SUM.asUInt
+                val correctionSubtractIO = Adder(PrefixAdderParameter(highWidth, 4))
+                correctionSubtractIO.a  := rawHigh.asBits
+                correctionSubtractIO.b  := ~geometry.residual.U(highWidth).asBits
+                correctionSubtractIO.ci := true.B
+                val subtracted   = correctionSubtractIO.sum.asUInt
                 // Keep this selection bitwise to preserve the reference combinational structure without GTECH cells.
                 val selectedBits = Vector.tabulate(highWidth): bit =>
                   wrapped ? (subtracted.asBits.bit(bit), rawHigh.asBits.bit(bit))
@@ -283,13 +278,11 @@ private final class AsyncDirection(
 
             val addressShift      = geometry.shift - 1
             val addressHighWidth  = pointerWidth - addressShift
-            val addressSubtractor = BrentKungAdder.instantiate(BrentKungAdderParameter(addressHighWidth, 4))
-            val addressSubtractIO =
-              addressSubtractor.io.asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
-            addressSubtractIO.A  := advancedPointer.asBits.bits(pointerWidth - 1, addressShift)
-            addressSubtractIO.B  := ~(startCount >> addressShift).U(addressHighWidth).asBits
-            addressSubtractIO.CI := true.B
-            val addressHigh = addressSubtractIO.SUM.asUInt
+            val addressSubtractIO = Adder(PrefixAdderParameter(addressHighWidth, 4))
+            addressSubtractIO.a  := advancedPointer.asBits.bits(pointerWidth - 1, addressShift)
+            addressSubtractIO.b  := ~(startCount >> addressShift).U(addressHighWidth).asBits
+            addressSubtractIO.ci := true.B
+            val addressHigh = addressSubtractIO.sum.asUInt
             val correctedAddress: Node[UInt] =
               if addressShift == 0 then addressHigh
               else (addressHigh.asBits ## advancedPointer.asBits.bits(addressShift - 1, 0)).asUInt

--- a/stdlib/src/queue/default/AsyncQueue.scala
+++ b/stdlib/src/queue/default/AsyncQueue.scala
@@ -4,8 +4,7 @@ package me.jiuyang.stdlib.queue.default
 
 import java.lang.foreign.Arena
 
-import me.jiuyang.stdlib.adder.{Adder, PrefixAdderParameter}
-import me.jiuyang.stdlib.adder.default.{Incrementer, given}
+import me.jiuyang.stdlib.adder.default.{BrentKungAdder, Incrementer, PrefixAdderParameter}
 import me.jiuyang.stdlib.default.{Ram, RamParameter}
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
@@ -236,7 +235,7 @@ private final class AsyncDirection(
         val (writePointer, readPointer) = kind match
           case AsyncDirectionKind.Push => (advancedPointer, remoteBinary)
           case AsyncDirectionKind.Pop  => (remoteBinary, advancedPointer)
-        val wordCountSubtractIO         = Adder(PrefixAdderParameter(pointerWidth, 4))
+        val wordCountSubtractIO         = BrentKungAdder.instantiate(PrefixAdderParameter(pointerWidth, 4)).io
         wordCountSubtractIO.a  := writePointer.asBits
         wordCountSubtractIO.b  := ~readPointer.asBits
         wordCountSubtractIO.ci := true.B
@@ -252,14 +251,14 @@ private final class AsyncDirection(
             val rawHigh   = rawWordCount.asBits.bits(pointerWidth - 1, geometry.shift).asUInt
             val correctedHigh: Node[UInt] =
               if geometry.residual == 1 then
-                val decrementSubtractIO = Adder(PrefixAdderParameter(highWidth, 4))
+                val decrementSubtractIO = BrentKungAdder.instantiate(PrefixAdderParameter(highWidth, 4)).io
                 decrementSubtractIO.a  := rawHigh.asBits
                 decrementSubtractIO.b  := ~1.U(highWidth).asBits
                 decrementSubtractIO.ci := true.B
                 val decremented = decrementSubtractIO.sum.asUInt
                 wrapped ? (decremented, rawHigh)
               else
-                val correctionSubtractIO = Adder(PrefixAdderParameter(highWidth, 4))
+                val correctionSubtractIO = BrentKungAdder.instantiate(PrefixAdderParameter(highWidth, 4)).io
                 correctionSubtractIO.a  := rawHigh.asBits
                 correctionSubtractIO.b  := ~geometry.residual.U(highWidth).asBits
                 correctionSubtractIO.ci := true.B
@@ -278,7 +277,7 @@ private final class AsyncDirection(
 
             val addressShift      = geometry.shift - 1
             val addressHighWidth  = pointerWidth - addressShift
-            val addressSubtractIO = Adder(PrefixAdderParameter(addressHighWidth, 4))
+            val addressSubtractIO = BrentKungAdder.instantiate(PrefixAdderParameter(addressHighWidth, 4)).io
             addressSubtractIO.a  := advancedPointer.asBits.bits(pointerWidth - 1, addressShift)
             addressSubtractIO.b  := ~(startCount >> addressShift).U(addressHighWidth).asBits
             addressSubtractIO.ci := true.B

--- a/stdlib/src/queue/default/SyncQueue.scala
+++ b/stdlib/src/queue/default/SyncQueue.scala
@@ -5,6 +5,8 @@ package me.jiuyang.stdlib.queue.default
 import java.lang.foreign.Arena
 
 import me.jiuyang.stdlib.*
+import me.jiuyang.stdlib.adder.{Adder, PrefixAdderParameter}
+import me.jiuyang.stdlib.adder.default.{Incrementer, given}
 import me.jiuyang.stdlib.default.{*, given}
 import me.jiuyang.stdlib.queue.*
 import me.jiuyang.zaozi.*
@@ -139,9 +141,9 @@ object SyncQueue extends Generator[SyncQueueParameter, SyncQueueLayers, SyncQueu
     val writeN = io.pushRequestN | (full & io.popRequestN)
     val read   = !io.popRequestN & notEmpty
 
-    val writeAddressIncrementer = Incrementer.instantiate(BKAIncrementerParameter(addressWidth))
-    writeAddressIncrementer.io.A := writeAddress.asBits
-    val writeAddressPlusOne = writeAddressIncrementer.io.SUM.asUInt
+    val writeAddressIncrementer = Incrementer.instantiate(PrefixAdderParameter(addressWidth))
+    writeAddressIncrementer.io.a := writeAddress.asBits
+    val writeAddressPlusOne = writeAddressIncrementer.io.sum.asUInt
     val nextWriteAddress    = Wire(UInt(addressWidth))
     nextWriteAddress := writeAddress
     when(!writeN) {
@@ -152,9 +154,9 @@ object SyncQueue extends Generator[SyncQueueParameter, SyncQueueLayers, SyncQueu
       }
     }
 
-    val readAddressIncrementer = Incrementer.instantiate(BKAIncrementerParameter(addressWidth))
-    readAddressIncrementer.io.A := readAddress.asBits
-    val readAddressPlusOne = readAddressIncrementer.io.SUM.asUInt
+    val readAddressIncrementer = Incrementer.instantiate(PrefixAdderParameter(addressWidth))
+    readAddressIncrementer.io.a := readAddress.asBits
+    val readAddressPlusOne = readAddressIncrementer.io.sum.asUInt
     // Diagnostic mode follows the DWBB interface: pulling diagnosticN low returns the read pointer to address zero.
     val diagnosticClear    = if parameter.enableDiagnostics then !io.diagnosticN else Node(false.B)
     val nextReadAddress    = Wire(UInt(addressWidth))
@@ -177,16 +179,14 @@ object SyncQueue extends Generator[SyncQueueParameter, SyncQueueLayers, SyncQueu
     val incrementWordCount   =
       (!io.pushRequestN & io.popRequestN & !full) | (!io.pushRequestN & !notEmpty)
     val decrementWordCount   = io.pushRequestN & !io.popRequestN & notEmpty
-    val wordCountIncrementer = Incrementer.instantiate(BKAIncrementerParameter(addressWidth))
-    wordCountIncrementer.io.A := wordCount.asBits
-    val wordCountPlusOne    = wordCountIncrementer.io.SUM.asUInt
-    val wordCountSubtractor = BrentKungAdder.instantiate(BrentKungAdderParameter(addressWidth, 4))
-    val wordCountSubtractIO =
-      wordCountSubtractor.io.asInstanceOf[Interface[PrefixAdderIO[BrentKungAdderParameter]]]
-    wordCountSubtractIO.A  := wordCount.asBits
-    wordCountSubtractIO.B  := ~1.U(addressWidth).asBits
-    wordCountSubtractIO.CI := true.B
-    val wordCountMinusOne = wordCountSubtractIO.SUM.asUInt
+    val wordCountIncrementer = Incrementer.instantiate(PrefixAdderParameter(addressWidth))
+    wordCountIncrementer.io.a := wordCount.asBits
+    val wordCountPlusOne    = wordCountIncrementer.io.sum.asUInt
+    val wordCountSubtractIO = Adder(PrefixAdderParameter(addressWidth, 4))
+    wordCountSubtractIO.a  := wordCount.asBits
+    wordCountSubtractIO.b  := ~1.U(addressWidth).asBits
+    wordCountSubtractIO.ci := true.B
+    val wordCountMinusOne = wordCountSubtractIO.sum.asUInt
     val advancedWordCount = decrementWordCount ? (wordCountMinusOne, wordCountPlusOne)
     val nextWordCount     = (incrementWordCount | decrementWordCount) ? (advancedWordCount, Node(wordCount))
 

--- a/stdlib/src/queue/default/SyncQueue.scala
+++ b/stdlib/src/queue/default/SyncQueue.scala
@@ -5,8 +5,7 @@ package me.jiuyang.stdlib.queue.default
 import java.lang.foreign.Arena
 
 import me.jiuyang.stdlib.*
-import me.jiuyang.stdlib.adder.{Adder, PrefixAdderParameter}
-import me.jiuyang.stdlib.adder.default.{Incrementer, given}
+import me.jiuyang.stdlib.adder.default.{BrentKungAdder, Incrementer, PrefixAdderParameter}
 import me.jiuyang.stdlib.default.{*, given}
 import me.jiuyang.stdlib.queue.*
 import me.jiuyang.zaozi.*
@@ -182,7 +181,7 @@ object SyncQueue extends Generator[SyncQueueParameter, SyncQueueLayers, SyncQueu
     val wordCountIncrementer = Incrementer.instantiate(PrefixAdderParameter(addressWidth))
     wordCountIncrementer.io.a := wordCount.asBits
     val wordCountPlusOne    = wordCountIncrementer.io.sum.asUInt
-    val wordCountSubtractIO = Adder(PrefixAdderParameter(addressWidth, 4))
+    val wordCountSubtractIO = BrentKungAdder.instantiate(PrefixAdderParameter(addressWidth, 4)).io
     wordCountSubtractIO.a  := wordCount.asBits
     wordCountSubtractIO.b  := ~1.U(addressWidth).asBits
     wordCountSubtractIO.ci := true.B

--- a/stdlib/tests/src/AdderSpec.scala
+++ b/stdlib/tests/src/AdderSpec.scala
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 xinpian-tech
+package me.jiuyang.stdlib
+
+import me.jiuyang.stdlib.adder.{AdderIO, AdderLayers, AdderParameter, AdderProbe}
+import me.jiuyang.testlib.*
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+import utest.*
+
+case class WidthOnlyAdderParameter(width: Int) extends AdderParameter
+given upickle.default.ReadWriter[WidthOnlyAdderParameter] = upickle.default.macroRW
+
+object AdderSpec extends TestSuite:
+  val tests = Tests:
+    test("Adder interfaces accept a width-only parameter"):
+      @generator
+      object WidthOnlyAdder
+          extends Generator[
+            WidthOnlyAdderParameter,
+            AdderLayers[WidthOnlyAdderParameter],
+            AdderIO[WidthOnlyAdderParameter],
+            AdderProbe[WidthOnlyAdderParameter]
+          ]
+          with HasFirrtlTest:
+        def architecture(parameter: WidthOnlyAdderParameter) =
+          val io = summon[Interface[AdderIO[WidthOnlyAdderParameter]]]
+          io.sum := io.a
+          io.co  := io.ci
+
+      for width <- Seq(1, 8) do
+        WidthOnlyAdder.firrtlTest(WidthOnlyAdderParameter(width))(
+          s"input a : UInt<$width>",
+          s"input b : UInt<$width>",
+          "input ci : UInt<1>",
+          "output co : UInt<1>",
+          s"output sum : UInt<$width>",
+          "connect sum, a",
+          "connect co, ci"
+        )

--- a/stdlib/tests/src/AdderSpec.scala
+++ b/stdlib/tests/src/AdderSpec.scala
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2026 xinpian-tech
 package me.jiuyang.stdlib
 
-import me.jiuyang.stdlib.adder.{AdderIO, AdderLayers, AdderParameter, AdderProbe}
+import me.jiuyang.stdlib.adder.*
+import me.jiuyang.stdlib.adder.default.{BrentKungAdder, PrefixAdderParameter, RippleAdderParameter, given}
 import me.jiuyang.testlib.*
 import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.default.{*, given}
@@ -15,6 +16,59 @@ given upickle.default.ReadWriter[WidthOnlyAdderParameter] = upickle.default.macr
 
 object AdderSpec extends TestSuite:
   val tests = Tests:
+    test("Ripple parameters validate width and serialize"):
+      intercept[IllegalArgumentException](RippleAdderParameter(0))
+      intercept[IllegalArgumentException](RippleAdderParameter(-1))
+      val parameter = RippleAdderParameter(8)
+      assert(upickle.default.read[RippleAdderParameter](upickle.default.write(parameter)) == parameter)
+
+    test("Default Adder accepts a custom parameter and instantiates RippleAdder"):
+      @generator
+      object DefaultAdder
+          extends Generator[
+            WidthOnlyAdderParameter,
+            AdderLayers[WidthOnlyAdderParameter],
+            AdderIO[WidthOnlyAdderParameter],
+            AdderProbe[WidthOnlyAdderParameter]
+          ]
+          with HasFirrtlTest:
+        def architecture(parameter: WidthOnlyAdderParameter) =
+          val io = summon[Interface[AdderIO[WidthOnlyAdderParameter]]]
+          val adder: Wire[AdderIO[WidthOnlyAdderParameter]] = Adder(parameter)
+          adder.a  := io.a
+          adder.b  := io.b
+          adder.ci := io.ci
+          io.sum   := adder.sum
+          io.co    := adder.co
+
+      for width <- Seq(1, 5, 32) do
+        DefaultAdder.firrtlTest(WidthOnlyAdderParameter(width))(out =>
+          out.contains(s"of RippleAdder_width$width") && !out.contains("BrentKungAdder")
+        )
+
+    test("BKA remains explicitly instantiable"):
+      @generator
+      object ExplicitBKA
+          extends Generator[
+            PrefixAdderParameter,
+            AdderLayers[PrefixAdderParameter],
+            AdderIO[PrefixAdderParameter],
+            AdderProbe[PrefixAdderParameter]
+          ]
+          with HasFirrtlTest:
+        def architecture(parameter: PrefixAdderParameter) =
+          val io    = summon[Interface[AdderIO[PrefixAdderParameter]]]
+          val adder = BrentKungAdder.instantiate(parameter).io
+          adder.a  := io.a
+          adder.b  := io.b
+          adder.ci := io.ci
+          io.sum   := adder.sum
+          io.co    := adder.co
+
+      ExplicitBKA.firrtlTest(PrefixAdderParameter(8, 2))(out =>
+        out.contains("of BrentKungAdder_width8_radix2") && !out.contains("RippleAdder")
+      )
+
     test("Adder interfaces accept a width-only parameter"):
       @generator
       object WidthOnlyAdder

--- a/zaozi/src/magic/macros/Generator.scala
+++ b/zaozi/src/magic/macros/Generator.scala
@@ -48,7 +48,11 @@ class generator extends MacroAnnotation:
             MethodType(List("parameter"))(methodType => List(tptParam.tpe), methodType => resultType.tpe)
           ),
           (argss: List[List[Tree]]) =>
-            Some(Select.unique(New(resultType), "<init>").appliedTo(argss.head.head.asExpr.asTerm))
+            val constructor        = Select.unique(New(resultType), "<init>")
+            val appliedConstructor = resultType.tpe match
+              case AppliedType(_, typeArgs) => constructor.appliedToTypes(typeArgs)
+              case _                        => constructor
+            Some(appliedConstructor.appliedTo(argss.head.head.asExpr.asTerm))
         )
 
         def parseParameterDef =


### PR DESCRIPTION
## Refactor stdlib adder interfaces and implementations

Organize adders around shared interfaces and default implementations, following the stdlib queue structure.

- Move Brent-Kung Adder, Incrementer, and prefix-tree helpers into `adder.default`.
- Introduce `AdderParameter` with `width`, and share `PrefixAdderParameter(width, radix)` between both implementations.
- Make `AdderIO`, `AdderLayers`, and `AdderProbe` generic over `P <: AdderParameter`.
- Add the `Adder` entry point and Brent-Kung `AdderImpl`; update queue and `AbsVal` call sites.
- Rename adder and incrementer signals to lowercase.
- Fix `@generator` to pass type arguments when constructing generic interfaces.

Existing arithmetic algorithms and contracts are preserved. Consumers must update imports, parameter types, and port names.

### Validation

- Compilation and formatting checks passed.
- 21 stdlib unit tests and all 11 lit cases passed.
- Reran the generic interface regression and Brent-Kung lit test after the final generic Layers/Probe changes.